### PR TITLE
add support for extra headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+app
 public
 workspace
 !test/workspace

--- a/config/config.development.json.sample
+++ b/config/config.development.json.sample
@@ -43,6 +43,9 @@
       "text/css": "public, max-age=86400",
       "text/javascript": "",
       "application/javascript": ""
+    },
+    "cors": {
+      "Access-Control-Allow-Origin": "*"
     }
   },
   "caching": {

--- a/config/config.production.json.sample
+++ b/config/config.production.json.sample
@@ -43,6 +43,9 @@
       "text/css": "public, max-age=86400",
       "text/javascript": "public, max-age=86400",
       "application/javascript": "public, max-age=86400"
+    },
+    "cors": {
+      "Access-Control-Allow-Origin": "*"
     }
   },
   "caching": {

--- a/config/config.qa.json.sample
+++ b/config/config.qa.json.sample
@@ -43,6 +43,9 @@
       "text/css": "public, max-age=86400",
       "text/javascript": "public, max-age=86400",
       "application/javascript": "public, max-age=86400"
+    },
+    "cors": {
+      "Access-Control-Allow-Origin": "*"
     }
   },
   "caching": {

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -54,6 +54,9 @@
       "text/css": "public, max-age=86400",
       "text/javascript": "public, max-age=86400",
       "application/javascript": "public, max-age=86400"
+    },
+    "cors": {
+      "Access-Control-Allow-Origin": "*"
     }
   },
   "caching": {

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -109,29 +109,43 @@ module.exports.sendBackJSONP = function (callbackName, res, next) {
 
 // helper that sends html response
 module.exports.sendBackHTML = function (method, successCode, contentType, res, next) {
-    return function (err, results) {
 
-        if (err) {
-          console.log(err);
-          return next(err);
-        }
+  return function (err, results) {
 
-        var resBody = results;
-
-        res.statusCode = successCode;
-        res.setHeader('Server', config.get('server.name'));
-        //res.setHeader('Cache-Control', 'private, max-age=600');
-        res.setHeader('Content-Type', contentType);
-        res.setHeader('Content-Length', Buffer.byteLength(resBody));
-
-        if (method.toLowerCase() === 'head') {
-          res.setHeader('Connection', 'close');
-          return res.end("");
-        }
-        else {
-          return res.end(resBody);
-        }
+    if (err) {
+      console.log(err);
+      return next(err);
     }
+
+    var resBody = results;
+
+    res.statusCode = successCode;
+    res.setHeader('Server', config.get('server.name'));
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Length', Buffer.byteLength(resBody));
+    //res.setHeader('Cache-Control', 'private, max-age=600');
+
+    self.addHeaders(res);
+
+    if (method.toLowerCase() === 'head') {
+      res.setHeader('Connection', 'close');
+      return res.end("");
+    }
+    else {
+      return res.end(resBody);
+    }
+  }
+}
+
+module.exports.addHeaders = function(res) {
+  var headers = config.get('headers');
+
+  _.each(headers.cors, function(value, header) {
+    res.setHeader(header, value);
+    if (header === 'Access-Control-Allow-Origin' && value !== '*') {
+      res.setHeader('Vary', 'Origin');
+    }
+  });
 }
 
 module.exports.getStaticData = function(datasource, done) {


### PR DESCRIPTION
Adds a method to include additional configured headers - focussed initially on CORS headers.

Add to your config file:

```
{
  ...
  "headers": {
    "cors": {
      "Access-Control-Allow-Origin": "*"
    }
  },
  ...
}
```
