### PR TITLE
Fix fields syntax in sample DS

### DIFF
--- a/sample-workspace/data-sources/articles.json
+++ b/sample-workspace/data-sources/articles.json
@@ -20,6 +20,9 @@
 			{ "field": "_id", "order": "asc" }
 		],
 		"search": {"title": "/(third)/iu"},
-		"fields": ["title", "author"]
+		"fields": {
+			"title": 1,
+			"author": 1
+		}
 	}
 }

--- a/sample-workspace/data-sources/books.json
+++ b/sample-workspace/data-sources/books.json
@@ -1,37 +1,40 @@
 {
 	"datasource": {
-		"key": "books",
-		"name": "Books datasource",
-		"source": {
-			"type": "remote",
-			"protocol": "http",
-			"host": "127.0.0.1",
-			"port": "3000",
-			"endpoint": "vjoin/testdb/books"
-		},
-    "caching": {
-        "enabled": true,
-        "ttl": 300,
-        "directory": "./cache/web/",
-        "extension": "json"
-    },
-    "auth": {
-        "type": "bearer",
-        "host": "127.0.0.1",
-        "port": "3000",
-        "tokenUrl": "/token",
-        "credentials": {
-            "clientId": "testClient",
-            "secret": "superSecret"
-        }
-    },
-		"paginate": true,
-		"count": 5,
-		"sort": [
-      {"field": "name","order": "desc"}
-    ],
-		"search": {},
-		"fields": ["name","authorId"],
-    "requestParams": ["authorId"]
-	}
+    	"key": "books",
+    	"name": "Books datasource",
+    	"source": {
+    		"type": "remote",
+    		"protocol": "http",
+    		"host": "127.0.0.1",
+    		"port": "3000",
+    		"endpoint": "vjoin/testdb/books"
+    	},
+        "caching": {
+            "enabled": true,
+            "ttl": 300,
+            "directory": "./cache/web/",
+            "extension": "json"
+        },
+        "auth": {
+            "type": "bearer",
+            "host": "127.0.0.1",
+            "port": "3000",
+            "tokenUrl": "/token",
+            "credentials": {
+                "clientId": "testClient",
+                "secret": "superSecret"
+            }
+        },
+    	"paginate": true,
+    	"count": 5,
+    	"sort": [
+          {"field": "name","order": "desc"}
+        ],
+    	"search": {},
+    	"fields": {
+            "name": 1,
+            "authorId": 1
+        },
+        "requestParams": ["authorId"]
+    }
 }

--- a/sample-workspace/data-sources/car-makes.json
+++ b/sample-workspace/data-sources/car-makes.json
@@ -1,39 +1,42 @@
 {
 	"datasource": {
-		"key": "car-makes",
-		"name": "Makes datasource",
-		"source": {
-			"type": "remote",
-			"protocol": "http",
-			"host": "127.0.0.1",
-			"port": "3000",
-			"endpoint": "1.0/car-data/makes"
-		},
-    "caching": {
-        "enabled": true,
-        "ttl": 300,
-        "directory": "./cache/web/",
-        "extension": "json"
-    },
-    "auth": {
-        "type": "bearer",
-        "host": "127.0.0.1",
-        "port": "3000",
-        "tokenUrl": "/token",
-        "credentials": {
-            "clientId": "testClient",
-            "secret": "superSecret"
-        }
-    },
-		"paginate": true,
-		"count": 20,
-		"sort": [
+    	"key": "car-makes",
+    	"name": "Makes datasource",
+    	"source": {
+    		"type": "remote",
+    		"protocol": "http",
+    		"host": "127.0.0.1",
+    		"port": "3000",
+    		"endpoint": "1.0/car-data/makes"
+    	},
+        "caching": {
+            "enabled": true,
+            "ttl": 300,
+            "directory": "./cache/web/",
+            "extension": "json"
+        },
+        "auth": {
+            "type": "bearer",
+            "host": "127.0.0.1",
+            "port": "3000",
+            "tokenUrl": "/token",
+            "credentials": {
+                "clientId": "testClient",
+                "secret": "superSecret"
+            }
+        },
+    	"paginate": true,
+    	"count": 20,
+    	"sort": [
             { "field": "name", "order": "asc" }
         ],
-		"search": {},
-		"fields": ["name","capId"],
+    	"search": {},
+    	"fields": {
+            "name": 1,
+            "capId": 1
+        },
         "requestParams": [
             { "param": "make", "field": "name" }
         ]
-	}
+    }
 }

--- a/sample-workspace/data-sources/car-models.json
+++ b/sample-workspace/data-sources/car-models.json
@@ -32,7 +32,11 @@
         ],
 		"search": {},
         "filter": ["{car-makes}",{"$group": {"_id" : {"make":"$makeName", "model":"$modelName","body":"$bodyStyle"}}}],
-		"fields": ["name","makeId","capId"],
+		"fields": {
+            "name": 1,
+            "makeId": 1,
+            "capId": 1
+        },
         "requestParams": [
           { "param": "model", "field": "name" }
         ],


### PR DESCRIPTION
From what I understand, the syntax for the `fields` field on datasources in API changed from an array of strings to a object with field names as keys.

This PR changes the sample datasources to reflect this new syntax, as currently the correct fields will not be attached to the datasource.

(Also, fixed the indentation on two of them #OCD) 