### PR TITLE
Datasource sort as object keys

### DIFF
--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -151,7 +151,7 @@ Datasource.prototype.processDatasourceParameters = function (schema, uri) {
     {"referer": schema.datasource.referer},
     {"filter": schema.datasource.filter || {}},
     {"fields": schema.datasource.fields || {}},
-    {"sort": processSortParameter(schema.datasource.sort)}
+    {"sort": schema.datasource.sort || {}}
   ];
 
   // pass cache flag to Serama endpoint
@@ -237,19 +237,6 @@ Datasource.prototype.processRequest = function (datasource, req) {
   }, this);
 
   this.buildEndpoint(this.schema, function() {});
-}
-
-function processSortParameter(obj) {
-  var sort = {};
-  if (typeof obj !== 'object' || obj === null) return sort;
-
-  _.each(obj, function(value, key) {
-    if (typeof value === 'object' && value.hasOwnProperty('field') && value.hasOwnProperty('order')) {
-      sort[value.field] = (value.order === 'asc') ? 1 : -1;
-    }
-  });
-
-  return sort;
 }
 
 module.exports = function (page, datasource, options, callback) {

--- a/demo/workspace/data-sources/films.json
+++ b/demo/workspace/data-sources/films.json
@@ -61,10 +61,7 @@
 		"cache": false,
 		"paginate": true,
 		"count": 10,
-		"sort": {
-			"field": "title",
-			"order": "desc"
-		},
+		"sort": { "title": -1 },
 		"search": {},
 		"fields": {"_id":1,"title":1,"director":1,"poster":1,"author":1,"length":1,"score":1,"reviews":1}
 	}

--- a/demo/workspace/data-sources/reviews.json
+++ b/demo/workspace/data-sources/reviews.json
@@ -4,7 +4,7 @@
 		"name": "Reviews DS",
 		"source": {
 			"type": "static",
-			"data": 
+			"data":
 				[
 					{
 						"_id": "83afa2ab-bf9d-4b7c-94f9-b63f8d6193b0",
@@ -18,12 +18,8 @@
 		"cache": false,
 		"paginate": true,
 		"count": 5,
-		"sort": {
-			"field": "_id",
-			"order": "desc"
-		},
+		"sort": { "_id":-1 },
 		"search": {},
 		"fields": ["_id","film_id","title","author","body"]
 	}
 }
-

--- a/sample-workspace/data-sources/articles.json
+++ b/sample-workspace/data-sources/articles.json
@@ -16,9 +16,7 @@
 		],
 
 		"count": 5,
-		"sort": [
-			{ "field": "_id", "order": "asc" }
-		],
+		"sort": { "_id":1 },
 		"search": {"title": "/(third)/iu"},
 		"fields": {
 			"title": 1,

--- a/sample-workspace/data-sources/books.json
+++ b/sample-workspace/data-sources/books.json
@@ -27,9 +27,7 @@
         },
     	"paginate": true,
     	"count": 5,
-    	"sort": [
-          {"field": "name","order": "desc"}
-        ],
+    	"sort": { "name":1 },
     	"search": {},
     	"fields": {
             "name": 1,

--- a/sample-workspace/data-sources/car-makes.json
+++ b/sample-workspace/data-sources/car-makes.json
@@ -27,9 +27,7 @@
         },
     	"paginate": true,
     	"count": 20,
-    	"sort": [
-            { "field": "name", "order": "asc" }
-        ],
+    	"sort": { "name":1 },
     	"search": {},
     	"fields": {
             "name": 1,

--- a/sample-workspace/data-sources/car-models.json
+++ b/sample-workspace/data-sources/car-models.json
@@ -27,11 +27,9 @@
     },
 		"paginate": true,
 		"count": 5,
-		"sort": [
-            {"field": "name","order": "desc"}
-        ],
+		"sort": { "name": -1 },
 		"search": {},
-        "filter": ["{car-makes}",{"$group": {"_id" : {"make":"$makeName", "model":"$modelName","body":"$bodyStyle"}}}],
+    "filter": ["{car-makes}",{"$group": {"_id" : {"make":"$makeName", "model":"$modelName","body":"$bodyStyle"}}}],
 		"fields": {
             "name": 1,
             "makeId": 1,

--- a/test/app/datasources/car-makes-unchained.json
+++ b/test/app/datasources/car-makes-unchained.json
@@ -27,9 +27,7 @@
     },
   	"paginate": true,
   	"count": 20,
-  	"sort": [
-          { "field": "name", "order": "asc" }
-      ],
+  	"sort": { "name":1 },
   	"search": {},
     "filter": {},
   	"fields": { "name": 1, "_id": 0 },

--- a/test/app/datasources/car-makes.json
+++ b/test/app/datasources/car-makes.json
@@ -27,9 +27,7 @@
     },
   	"paginate": true,
   	"count": 20,
-  	"sort": [
-          { "field": "name", "order": "asc" }
-      ],
+  	"sort": { "name":1 },
   	"search": {},
     "filter": {},
   	"fields": { "name": 1, "_id": 0 },

--- a/test/app/datasources/car-models.json
+++ b/test/app/datasources/car-models.json
@@ -27,9 +27,7 @@
     },
   	"paginate": true,
   	"count": 20,
-  	"sort": [
-      { "field": "name", "order": "asc" }
-    ],
+  	"sort": { "name":1 },
   	"search": {},
     "filter": {},
   	"fields": { "name": 1, "_id": 0 },

--- a/test/app/datasources/categories.json
+++ b/test/app/datasources/categories.json
@@ -17,9 +17,7 @@
     },
   	"paginate": true,
   	"count": 20,
-  	"sort": [
-      { "field": "name", "order": "asc" }
-    ],
+  	"sort": { "name":1 },
   	"search": {},
     "filter": {},
   	"fields": { "name": 1, "_id": 0 },

--- a/test/app/datasources/filters.json
+++ b/test/app/datasources/filters.json
@@ -11,9 +11,7 @@
 		},
   	"paginate": true,
   	"count": 20,
-  	"sort": [
-      { "field": "name", "order": "asc" }
-    ],
+  	"sort": { "name":1 },
   	"search": {},
     "filter": { "y": "2" },
     "filterEvent": "test_filter_event",

--- a/test/app/datasources/test-cars-ds.json
+++ b/test/app/datasources/test-cars-ds.json
@@ -27,9 +27,7 @@
     },
   	"paginate": true,
   	"count": 20,
-  	"sort": [
-      { "field": "name", "order": "asc" }
-    ],
+  	"sort": { "name":1 },
   	"search": {},
     "filter": {},
   	"fields": { "name": 1, "_id": 0 },


### PR DESCRIPTION
Close #19 

This PR replaces the current datasource sort property (as Array of fields) with a simple object like the MongoDB sort property:

To sort by the field "name" ascending:
```
"sort": { "name": 1 } 
``` 

To sort by the field "name" descending:
```
"sort": { "name": -1 } 
``` 

To sort by multiple fields:
```
"sort": { "name": 1, "age": -1 } 
``` 