### PR TITLE
Add /status endpoint

### DIFF
--- a/dadi/lib/health/index.js
+++ b/dadi/lib/health/index.js
@@ -1,0 +1,88 @@
+var version = require(__dirname + '/../../../package.json').version;
+var url = require('url');
+var latestVersion = require('latest-version');
+var os = require('os');
+var _ = require('underscore');
+var config = require(__dirname + '/../../../config');
+var help = require(__dirname + '/../help');
+var request = require('request');
+var async = require('async');
+
+
+module.exports = function (server) {
+  var unit = ['', 'K', 'M', 'G', 'T', 'P'];
+
+  var bytesToSize = function(input, precision)
+  {
+    var index = Math.floor(Math.log(input) / Math.log(1024));
+    if (unit >= unit.length) return input + ' B';
+    return (input / Math.pow(1024, index)).toFixed(precision) + ' ' + unit[index] + 'B';
+  };
+
+  server.app.use('/status', function(req, res, next) {
+    var authorization = req.headers.authorization;
+    var method = req.method && req.method.toLowerCase();
+    if(method === 'get' && config.get('status.enabled')) {
+      var healthRoutes = config.get('health.routes');
+      var healthTimeLimit = config.get('health.timeLimit');
+
+      return latestVersion('test').then(function(result) {
+        var routesCallbacks = [];
+        _.each(healthRoutes, function(route) {
+          var start = new Date();
+          routesCallbacks.push(function(cb) {
+            request({
+              url: 'http://' + config.get('server.host') + ':' + config.get('server.port') + route, 
+              headers: {
+                'Authorization': authorization
+              }
+            }, function(err, response, body) {
+              var responseTime = (new Date() - start) / 1000;
+              var usage = process.memoryUsage();
+              var health = {
+                route: route,
+                pid: process.pid,
+                uptime: process.uptime()+' seconds',
+                memory: {
+                  rss: bytesToSize(usage.rss, 3),
+                  heapTotal: bytesToSize(usage.heapTotal, 3),
+                  heapUsed: bytesToSize(usage.heapUsed, 3)
+                }
+              };
+              health.responseTime = responseTime;
+              if (!err && response.statusCode == 200) {
+                if(responseTime < healthTimeLimit) {
+                  health.healthStatus = 'Green';
+                } else {
+                  health.healthStatus = 'Amber';
+                }
+              } else {
+                health.healthStatus = 'Red';
+              }
+              cb(err, health);
+            });
+          });
+        });
+        async.parallel(routesCallbacks, function(err, health) {
+          var usage = process.memoryUsage();
+          var data = {
+            current_version: version,
+            memory_usage: {
+              rss: bytesToSize(usage.rss, 3),
+              heapTotal: bytesToSize(usage.heapTotal, 3),
+              heapUsed: bytesToSize(usage.heapUsed, 3)
+            },
+            uptime: process.uptime()+' seconds',
+            load_avg: os.loadavg(),
+            latest_version: result,
+            routes_health: health
+          };
+          help.sendBackJSON(200, res, next)(null, data);
+        });
+          
+      });
+    }
+
+    next();
+  });
+};

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -50,6 +50,7 @@ var monitor = require(__dirname + '/monitor');
 var log = require(__dirname + '/log');
 var help = require(__dirname + '/help');
 var dustHelpersExtension = require(__dirname + '/dust/helpers.js');
+var health = require(__dirname + '/health');
 
 var config = require(path.resolve(__dirname + '/../../config.js'));
 
@@ -167,6 +168,8 @@ Server.prototype.start = function (done) {
       auth(self);
     }
 
+    health(self);
+    
     // handle routing & redirects
     router(self, options);
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "stack-trace": "latest",
     "toobusy-js": "^0.4.2",
     "underscore": "~1.6.0",
-    "underscore.string": "^3.2.2"
+    "underscore.string": "^3.2.2",
+    "latest-version": "~2.0.0",
+    "request": "~2.67.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.4",

--- a/test/acceptance/health.js
+++ b/test/acceptance/health.js
@@ -1,0 +1,59 @@
+var sinon = require('sinon');
+var should = require('should');
+var request = require('supertest');
+// loaded customised fakeweb module
+var fakeweb = require(__dirname + '/../fakeweb');
+var http = require('http');
+var _ = require('underscore');
+var path = require('path');
+var assert = require('assert');
+
+var Server = require(__dirname + '/../../dadi/lib');
+var help = require(__dirname + '/../help');
+var config = require(__dirname + '/../../config.js');
+
+var clientHost = 'http://' + config.get('server.host') + ':' + config.get('server.port');
+var apiHost = 'http://' + config.get('api.host') + ':' + config.get('api.port');
+
+var token = JSON.stringify({
+  "accessToken": "da6f610b-6f91-4bce-945d-9829cac5de71",
+  "tokenType": "Bearer",
+  "expiresIn": 2592000
+});
+
+describe('Health', function (done) {
+
+  beforeEach(function(done) {
+    Server.start(function() {
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    http.clear_intercepts();
+    Server.stop(function() {
+      done();
+    });
+  });
+  
+  it('should allow "/status" request without token', function (done) {
+    config.set('api.enabled', true);
+
+    http.register_intercept({
+      hostname: '127.0.0.1',
+      port: 3000,
+      path: '/token',
+      method: 'POST',
+      agent: new http.Agent({ keepAlive: true }),
+      headers: { 'Content-Type': 'application/json' },
+      body: token
+    });
+
+    var client = request(clientHost);
+
+    client
+    .get('/status')
+    .expect('content-type', 'application/json')
+    .expect(200, done);
+  });
+});


### PR DESCRIPTION
Fix #7 

Create '/status' endpoint to return current version and latest version of DADI Web, memory usage, uptime, cpu load averages and health indicator for the routes that are defined in configuration file.

@josephdenne, @jimlambie , please review.

Tests for '/status' endpoint all pass, in acceptance suite.