### PR TITLE
add sort processing method back, but allow different sort param types

### DIFF
--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -151,7 +151,7 @@ Datasource.prototype.processDatasourceParameters = function (schema, uri) {
     {"referer": schema.datasource.referer},
     {"filter": schema.datasource.filter || {}},
     {"fields": schema.datasource.fields || {}},
-    {"sort": schema.datasource.sort || {}}
+    {"sort": processSortParameter(schema.datasource.sort)}
   ];
 
   // pass cache flag to Serama endpoint
@@ -240,6 +240,27 @@ Datasource.prototype.processRequest = function (datasource, req) {
   }, this);
 
   this.buildEndpoint(this.schema, function() {});
+}
+
+function processSortParameter(obj) {
+  var sort = {};
+  if (typeof obj !== 'object' || obj === null) return sort;
+
+  if (_.isArray(obj)) {
+    _.each(obj, function(value, key) {
+      if (typeof value === 'object' && value.hasOwnProperty('field') && value.hasOwnProperty('order')) {
+        sort[value.field] = (value.order === 'asc') ? 1 : -1;
+      }
+    });
+  }
+  else if (obj.hasOwnProperty('field') && obj.hasOwnProperty('order')) {
+    sort[obj.field] = (obj.order === 'asc') ? 1 : -1;
+  }
+  else {
+    sort = obj;
+  }
+
+  return sort;
 }
 
 module.exports = function (page, datasource, options, callback) {

--- a/test/unit/datasource.js
+++ b/test/unit/datasource.js
@@ -322,6 +322,133 @@ describe('Datasource', function (done) {
     done();
   });
 
+  describe('processDatasourceParameters', function(done) {
+    it('should process sort parameter when it is an array', function (done) {
+      var name = 'test';
+      var schema = help.getPageSchema();
+      var p = page(name, schema);
+      var dsName = 'car-makes';
+      var options = help.getPathOptions();
+
+      var dsSchema = help.getSchemaFromFile(options.datasourcePath, dsName, 'requestParams');
+      dsSchema.datasource.sort = [{field: "name", order: "asc"}]
+      sinon.stub(datasource.Datasource.prototype, "loadDatasource").yields(null, dsSchema);
+
+      var ds = datasource(p, dsName, options, function() {} );
+
+      var params = { "make": "bmw" };
+      var req = { params: params, url: '/1.0/cars/makes' };
+
+      var endpoint = ds.processDatasourceParameters(dsSchema, req.url)
+
+      datasource.Datasource.prototype.loadDatasource.restore();
+
+      endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}');
+
+      done();
+    });
+
+    it('should process sort parameter when it is an array with many items', function (done) {
+      var name = 'test';
+      var schema = help.getPageSchema();
+      var p = page(name, schema);
+      var dsName = 'car-makes';
+      var options = help.getPathOptions();
+
+      var dsSchema = help.getSchemaFromFile(options.datasourcePath, dsName, 'requestParams');
+      dsSchema.datasource.sort = [{field: "name", order: "asc"},{field: "age", order: "desc"}]
+      sinon.stub(datasource.Datasource.prototype, "loadDatasource").yields(null, dsSchema);
+
+      var ds = datasource(p, dsName, options, function() {} );
+
+      var params = { "make": "bmw" };
+      var req = { params: params, url: '/1.0/cars/makes' };
+
+      var endpoint = ds.processDatasourceParameters(dsSchema, req.url)
+
+      datasource.Datasource.prototype.loadDatasource.restore();
+
+      endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1,"age":-1}');
+
+      done();
+    });
+
+    it('should process sort parameter when it is an object', function (done) {
+      var name = 'test';
+      var schema = help.getPageSchema();
+      var p = page(name, schema);
+      var dsName = 'car-makes';
+      var options = help.getPathOptions();
+
+      var dsSchema = help.getSchemaFromFile(options.datasourcePath, dsName, 'requestParams');
+      dsSchema.datasource.sort = {field: "name", order: "asc"}
+      sinon.stub(datasource.Datasource.prototype, "loadDatasource").yields(null, dsSchema);
+
+      var ds = datasource(p, dsName, options, function() {} );
+
+      var params = { "make": "bmw" };
+      var req = { params: params, url: '/1.0/cars/makes' };
+
+      var endpoint = ds.processDatasourceParameters(dsSchema, req.url)
+
+      datasource.Datasource.prototype.loadDatasource.restore();
+
+      endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}');
+
+      done();
+    });
+
+    it('should process sort parameter when it is a MongoDB-style object', function (done) {
+      var name = 'test';
+      var schema = help.getPageSchema();
+      var p = page(name, schema);
+      var dsName = 'car-makes';
+      var options = help.getPathOptions();
+
+      var dsSchema = help.getSchemaFromFile(options.datasourcePath, dsName, 'requestParams');
+      dsSchema.datasource.sort = {"name": 1}
+      sinon.stub(datasource.Datasource.prototype, "loadDatasource").yields(null, dsSchema);
+
+      var ds = datasource(p, dsName, options, function() {} );
+
+      var params = { "make": "bmw" };
+      var req = { params: params, url: '/1.0/cars/makes' };
+
+      var endpoint = ds.processDatasourceParameters(dsSchema, req.url)
+
+      datasource.Datasource.prototype.loadDatasource.restore();
+
+      endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}');
+
+      done();
+    });
+
+    it('should process sort parameter when it is a MongoDB-style object with many items', function (done) {
+      var name = 'test';
+      var schema = help.getPageSchema();
+      var p = page(name, schema);
+      var dsName = 'car-makes';
+      var options = help.getPathOptions();
+
+      var dsSchema = help.getSchemaFromFile(options.datasourcePath, dsName, 'requestParams');
+      dsSchema.datasource.sort = {"name": 1, "age": -1}
+      sinon.stub(datasource.Datasource.prototype, "loadDatasource").yields(null, dsSchema);
+
+      var ds = datasource(p, dsName, options, function() {} );
+
+      var params = { "make": "bmw" };
+      var req = { params: params, url: '/1.0/cars/makes' };
+
+      var endpoint = ds.processDatasourceParameters(dsSchema, req.url)
+
+      datasource.Datasource.prototype.loadDatasource.restore();
+
+      endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1,"age":-1}');
+
+      done();
+    });
+  })
+
   describe('processRequest', function(done) {
     it('should add requestParams to the endpoint', function (done) {
       var name = 'test';


### PR DESCRIPTION
An earlier commit removed the method that processed a sort parameter into a Mongo-style sort. This PR adds that back, and allow for different types of sort properties in datasource schemas:

1. Array
```
sort: [{"field":"name", "order":"asc"}]
```

2. Object
```
sort: {"field":"name", "order":"asc"}
```

3. MongoDB style
```
sort: {"name": 1, "age": -1}
```