### PR TITLE
use array instead of object for event container

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -29,8 +29,8 @@ var Controller = function (page, options) {
   this.options = options || {};
 
   this.datasources = {};
-  this.events = {};
-  this.preloadEvents = {};
+  this.events = [];
+  this.preloadEvents = [];
 
   var self = this;
 
@@ -68,12 +68,12 @@ Controller.prototype.attachEvents = function(done) {
 
   this.page.events.forEach(function(eventName) {
     var e = new Event(self.page.name, eventName, self.options);
-    self.events[eventName] = e;
+    self.events.push(e);
   });
 
   this.page.preloadEvents.forEach(function(eventName) {
     var e = new Event(self.page.name, eventName, self.options);
-    self.preloadEvents[eventName] = e;
+    self.preloadEvents.push(e);
   });
 
   done();
@@ -203,8 +203,8 @@ Controller.prototype.loadEventData = function (events, req, res, data, done) {
 
   var eventIdx = 0;
 
-  _.each(events, function(value, key) {
-      help.timer.start('event: ' + key);
+  _.each(events, function(event) {
+      help.timer.start('event: ' + event.name);
 
       // add a random value to the data obj so we can check if an
       // event has sent back the obj - in which case we assign it back
@@ -214,8 +214,8 @@ Controller.prototype.loadEventData = function (events, req, res, data, done) {
 
       // run the event
       try {
-        events[key].run(req, res, data, function (err, result) {
-          help.timer.stop('event: ' + key);
+        event.run(req, res, data, function (err, result) {
+          help.timer.stop('event: ' + event.name);
 
           if (err) {
             return done(err, data);
@@ -228,14 +228,14 @@ Controller.prototype.loadEventData = function (events, req, res, data, done) {
           }
           else if (result) {
             // add the result to our global data object
-            data[key] = result;
+            data[event.name] = result;
           }
 
           eventIdx++;
 
           // return the data if we're at the end of the events
           // array, we have all the responses to render the page
-          if (eventIdx === Object.keys(events).length) {
+          if (eventIdx === events.length) {
             return done(null, data);
           }
         });

--- a/test/app/events/a.js
+++ b/test/app/events/a.js
@@ -1,0 +1,20 @@
+var path = require('path');
+var http = require("http");
+var url = require('url');
+var querystring = require('querystring');
+var pathToRegexp = require('path-to-regexp');
+
+// the `data` parameter contains the data already loaded by
+// the page's datasources and any previous events that have fired
+var Event = function (req, res, data, callback) {
+
+  data = 'Results for B found: ' + (typeof data.b !== 'undefined').toString();
+
+  callback(null, data);
+};
+
+module.exports = function (req, res, data, callback) {
+  return new Event(req, res, data, callback);
+};
+
+module.exports.Event = Event;

--- a/test/app/events/b.js
+++ b/test/app/events/b.js
@@ -1,0 +1,20 @@
+var path = require('path');
+var http = require("http");
+var url = require('url');
+var querystring = require('querystring');
+var pathToRegexp = require('path-to-regexp');
+
+// the `data` parameter contains the data already loaded by
+// the page's datasources and any previous events that have fired
+var Event = function (req, res, data, callback) {
+
+  data = 'I came from B';
+
+  callback(null, data);
+};
+
+module.exports = function (req, res, data, callback) {
+  return new Event(req, res, data, callback);
+};
+
+module.exports.Event = Event;

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -141,6 +141,72 @@ describe('Controller', function (done) {
     return page;
   }
 
+  function getPage() {
+    // create a page
+    var name = 'test';
+    var schema = testHelper.getPageSchema();
+    var page = Page(name, schema);
+
+    page.contentType = 'application/json';
+    page.template = 'test.dust';
+    page.route.paths[0] = '/test';
+    page.settings.cache = false;
+
+    page.datasources = [];
+    page.events = ['test_event'];
+    delete page.route.constraint;
+
+    return page;
+  }
+
+  describe('Events', function(done) {
+    it('should load events in the order they are specified', function(done) {
+      config.set('api.enabled', false);
+
+      var page = getPage();
+      page.events = ['b','a']
+      controller = Controller(page, options);
+      controller.events.should.exist;
+      controller.events[0].name.should.eql('b');
+      controller.events[1].name.should.eql('a');
+      done();
+    })
+
+    it('should run events in the order they are specified', function(done) {
+      config.set('allowJsonView', true);
+      var page = getPage();
+      page.events = ['b','a']
+
+      startServer(page);
+
+      // provide API response
+      var apiResults = { results: [{_id: 1, title: 'books'}] }
+      sinon.stub(help.DataHelper.prototype, 'load').yields(null, apiResults);
+
+      // provide event response
+      var method = sinon.spy(Controller.Controller.prototype, 'loadEventData');
+
+      var client = request(connectionString);
+
+      client
+      .get(page.route.paths[0] + '?json=true')
+      //.expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+
+        method.called.should.eql(true);
+        method.secondCall.args[0][0].should.eql(controller.events[0])
+        method.restore()
+        help.DataHelper.prototype.load.restore();
+
+        res.body['b'].should.eql('I came from B');
+        res.body['a'].should.eql('Results for B found: true');
+
+        cleanup(done);
+      });
+    })
+  })
+
   describe('Preload Events', function(done) {
     it('should load preloadEvents in the controller instance', function(done) {
       config.set('api.enabled', false);
@@ -148,7 +214,7 @@ describe('Controller', function (done) {
       var page = getPageWithPreloadEvents();
       controller = Controller(page, options);
       controller.preloadEvents.should.exist;
-      controller.preloadEvents[page.preloadEvents[0]].should.exist;
+      controller.preloadEvents[0].name.should.eql(page.preloadEvents[0]);
       done();
     })
 


### PR DESCRIPTION
Events specified for a page were assigned to the data loader in a different order to that specified in the page specification file. This PR addresses that, loading each event into an array in the same order they were set in the page spec.