### PR TITLE
Global events

### DIFF
--- a/config.js
+++ b/config.js
@@ -234,6 +234,11 @@ var conf = convict({
       }
     }
   },
+  globalEvents: {
+    doc: "",
+    format: Array,
+    default: []
+  },
   paths: {
     doc: "",
     format: Object,

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -71,6 +71,12 @@ Controller.prototype.attachEvents = function(done) {
     self.events.push(e);
   });
 
+  // add global events first
+  config.get('globalEvents').forEach(function(eventName) {
+    var e = new Event(self.page.name, eventName, self.options);
+    self.preloadEvents[eventName] = e;
+  });
+
   this.page.preloadEvents.forEach(function(eventName) {
     var e = new Event(self.page.name, eventName, self.options);
     self.preloadEvents.push(e);
@@ -171,23 +177,10 @@ Controller.prototype.process = function (req, res, next) {
 
       view.setData(data);
 
-      //try {
       view.render(function(err, result) {
         if (err) return next(err);
         return done(null, result);
       });
-      // }
-      // catch (e) {
-      //   console.log(e)
-      //   var err = new Error(e.message);
-      //   err.statusCode = 500;
-      //   if (next) {
-      //     return next(err);
-      //   }
-      //   else {
-      //     return done(err);
-      //   }
-      // }
     });
 }
 

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -74,7 +74,7 @@ Controller.prototype.attachEvents = function(done) {
   // add global events first
   config.get('globalEvents').forEach(function(eventName) {
     var e = new Event(self.page.name, eventName, self.options);
-    self.preloadEvents[eventName] = e;
+    self.preloadEvents.push(e);
   });
 
   this.page.preloadEvents.forEach(function(eventName) {

--- a/test/app/events/test_global_event.js
+++ b/test/app/events/test_global_event.js
@@ -1,0 +1,20 @@
+var path = require('path');
+var http = require("http");
+var url = require('url');
+var querystring = require('querystring');
+var pathToRegexp = require('path-to-regexp');
+
+// the `data` parameter contains the data already loaded by
+// the page's datasources and any previous events that have fired
+var Event = function (req, res, data, callback) {
+
+  data.global_event = 'FIRED';
+
+  callback(null, data);
+};
+
+module.exports = function (req, res, data, callback) {
+  return new Event(req, res, data, callback);
+};
+
+module.exports.Event = Event;

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -160,6 +160,54 @@ describe('Controller', function (done) {
     return page;
   }
 
+  describe('Events', function(done) {
+    it('should load events in the order they are specified', function(done) {
+      config.set('api.enabled', false);
+
+      var page = getPage();
+      page.events = ['b','a']
+      controller = Controller(page, options);
+      controller.events.should.exist;
+      controller.events[0].name.should.eql('b');
+      controller.events[1].name.should.eql('a');
+      done();
+    })
+
+    it('should run events in the order they are specified', function(done) {
+      config.set('allowJsonView', true);
+      var page = getPage();
+      page.events = ['b','a']
+
+      startServer(page);
+
+      // provide API response
+      var apiResults = { results: [{_id: 1, title: 'books'}] }
+      sinon.stub(help.DataHelper.prototype, 'load').yields(null, apiResults);
+
+      // provide event response
+      var method = sinon.spy(Controller.Controller.prototype, 'loadEventData');
+
+      var client = request(connectionString);
+
+      client
+      .get(page.route.paths[0] + '?json=true')
+      //.expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+
+        method.called.should.eql(true);
+        method.secondCall.args[0][0].should.eql(controller.events[0])
+        method.restore()
+        help.DataHelper.prototype.load.restore();
+
+        res.body['b'].should.eql('I came from B');
+        res.body['a'].should.eql('Results for B found: true');
+
+        cleanup(done);
+      });
+    })
+  })
+
   describe('Preload Events', function(done) {
     it('should load preloadEvents in the controller instance', function(done) {
       config.set('api.enabled', false);
@@ -214,7 +262,7 @@ describe('Controller', function (done) {
       var page = getPage();
       controller = Controller(page, options);
       controller.preloadEvents.should.exist;
-      controller.preloadEvents['test_global_event'].should.exist;
+      controller.preloadEvents[0].name.should.eql('test_global_event');
       done();
     })
 


### PR DESCRIPTION
This PR allows a developer to add global events to the config so that they are run for every page:

**config.development.json**
```
"globalEvents":["event2","event1"]
```

Global events are added to the `preloadEvents` stack, but are run before the page-specific preloadEvents

Close #1 