### PR TITLE
Allow partials in sub-directories

### DIFF
--- a/app/pages/index.json
+++ b/app/pages/index.json
@@ -1,0 +1,9 @@
+{
+  "page": {
+    "name": "Index",
+    "description": "Index page.",
+    "language": "en"
+  },
+  "datasources": [],
+  "events": []
+}

--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -227,7 +227,11 @@ Datasource.prototype.processRequest = function (datasource, req) {
   // NB don't replace a property that already exists
   _.each(this.requestParams, function(obj) {
     if (req.params.hasOwnProperty(obj.param)) {
-      this.schema.datasource.filter[obj.field] = encodeURIComponent(req.params[obj.param]);
+      if (obj.type == "Number") {
+        this.schema.datasource.filter[obj.field] = Number(req.params[obj.param]);
+      } else {
+        this.schema.datasource.filter[obj.field] = encodeURIComponent(req.params[obj.param]);
+      }
     }
     else {
       // param not found in request, remove it from DS filter

--- a/test/help.js
+++ b/test/help.js
@@ -1,23 +1,11 @@
 /*
 
-TO DO
-
-page with request params
-page with query params
-page with request params and query params
-
-routing
- - req.params
- - querystring append
- - trailing slash
- - test constraints
-
+TO D)
 datasources
  - chained, param
  - chained, query
 
  */
-
 
 var assert = require('assert');
 var fs = require('fs');

--- a/test/unit/datasource.js
+++ b/test/unit/datasource.js
@@ -467,6 +467,32 @@ describe('Datasource', function (done) {
       done();
     });
 
+    it('should use specified type when adding requestParams to the endpoint', function (done) {
+      var name = 'test';
+      var schema = help.getPageSchema();
+      var p = page(name, schema);
+      var dsName = 'car-makes';
+      var options = help.getPathOptions();
+      var dsSchema = help.getSchemaFromFile(options.datasourcePath, dsName);
+      sinon.stub(datasource.Datasource.prototype, "loadDatasource").yields(null, dsSchema);
+
+      // add type
+      dsSchema.datasource.requestParams[0].type = 'Number'
+
+      var params = { "make": "1337" };
+      var req = { params: params, url: '/1.0/cars/makes' };
+
+      var ds = datasource(p, dsName, options, function() {});
+
+      datasource.Datasource.prototype.loadDatasource.restore();
+
+      ds.processRequest(dsName, req);
+
+      ds.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={"name":1337}&fields={"name":1,"_id":0}&sort={"name":1}');
+
+      done();
+    });
+
     it('should pass cache param to the endpoint', function (done) {
       var name = 'test';
       var schema = help.getPageSchema();


### PR DESCRIPTION
I noticed that currently Web breaks when there is a sub-directory inside `partials/`. This happens because `fs.readFileSync()` is being called without checking the type of its argument, and it throws an error and crashes the app when used on a directory:

*Example:*
```
.
└── partials/
    ├── parent.dust
    └── component1/
        └── child.dust
```

```
Error: EISDIR: illegal operation on a directory, read
    at Error (native)
    at Object.fs.readSync (fs.js:651:19)
    at Object.fs.readFileSync (fs.js:472:24)
    at /data/app/web/dadi/lib/index.js:611:28
    at Array.forEach (native)
    at Server.dustCompile (/data/app/web/dadi/lib/index.js:608:14)
    at null.<anonymous> (/data/app/web/dadi/lib/index.js:349:14)
    at emitOne (events.js:77:13)
    at emit (events.js:169:7)
    at FSWatcher.<anonymous> (/data/app/web/dadi/lib/monitor/index.js:15:14)
    at emitTwo (events.js:87:13)
    at FSWatcher.emit (events.js:172:7)
    at FSEvent.FSWatcher._handle.onchange (fs.js:1300:12)
```

I think it's important to able to separate partials into sub-directories (especially on larger projects), so this PR implements that.

I've added a recursive function that lists the partials directory and checks the type of each item, loading the template if it's a file or listing again if it's a sub-directory.

It's then possible to call partials in sub-directories like so:

```
{>"partials/parent" /}

{>"partials/component1/child" /}

{>"partials/component1/subcomponent1/grandchild" /}

(...)
```
@jimlambie @josephdenne thoughts?