### PR TITLE
Add sample index.json

### DIFF
--- a/app/pages/index.json
+++ b/app/pages/index.json
@@ -1,0 +1,9 @@
+{
+  "page": {
+    "name": "Index",
+    "description": "Index page.",
+    "language": "en"
+  },
+  "datasources": [],
+  "events": []
+}


### PR DESCRIPTION
I thought it'd be useful to add an `index.json` to the default `app/pages` directory, as the default page won't work without it, which might confuse new users.