### PR TITLE
[WIP] Add Passport integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Auth wallet
+.wallet
+
 public/*
 app/*
 workspace/*

--- a/config.js
+++ b/config.js
@@ -262,7 +262,8 @@ var conf = convict({
       pages: __dirname + '/app/pages',
       partials: __dirname + '/app/partials',
       public: __dirname + '/app/public',
-      routes: __dirname + '/app/routes'
+      routes: __dirname + '/app/routes',
+      tokenWallet: __dirname + '/.wallet'
     }
   },
   sessions: {

--- a/config.js
+++ b/config.js
@@ -39,6 +39,11 @@ var conf = convict({
       format: '*',
       default: '0.0.0.0'
     },
+    protocol: {
+      doc: "The protocol for the DADI API application",
+      format: String,
+      default: "http"
+    },
     port: {
       doc: "The port for the DADI API application",
       format: 'port',
@@ -55,6 +60,11 @@ var conf = convict({
       doc: "",
       format: String,
       default: "/token"
+    },
+    protocol: {
+      doc: "",
+      format: String,
+      default: "http"
     },
     clientId: {
       doc: "",

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -27,6 +27,8 @@
     "middleware": "test/app/middleware",
     "media": "test/app/media",
     "public": "test/app/public",
-    "routes": "test/app/routes"
+    "routes": "test/app/routes",
+    "filters": "test/app/utils/filters",
+    "helpers": "test/app/utils/helpers"
   }
 }

--- a/dadi/lib/auth/bearer.js
+++ b/dadi/lib/auth/bearer.js
@@ -1,3 +1,4 @@
+var config = require(__dirname + '/../../../config.js');
 var help = require(__dirname + '/../help');
 var log = require(__dirname + '/../log');
 var Passport = require(__dirname + '/../../../../passport/node/src'); // !!! TODO: Replace with NPM
@@ -15,18 +16,18 @@ BearerAuthStrategy.prototype.getType = function () {
 };
 
 BearerAuthStrategy.prototype.getToken = function (datasource, done) {
-  var config = datasource.authStrategy.config;
+  var strategy = datasource.authStrategy.config;
 
   Passport({
     issuer: {
-      uri: (config.protocol || 'http') + '://' + config.host,
-      port: config.port,
-      endpoint: config.tokenUrl
+      uri: (strategy.protocol || 'http') + '://' + strategy.host,
+      port: strategy.port,
+      endpoint: strategy.tokenUrl
     },
-    credentials: config.credentials,
+    credentials: strategy.credentials,
     wallet: 'file',
     walletOptions: {
-      path: __dirname + '/' + help.generateTokenWalletFilename(config.host, config.port, config.credentials.clientId)
+      path: config.get('paths.tokenWallet') + '/' + help.generateTokenWalletFilename(strategy.host, strategy.port, strategy.credentials.clientId)
     }
   }).then(function (bearerToken) {
     return done(null, bearerToken);

--- a/dadi/lib/auth/bearer.js
+++ b/dadi/lib/auth/bearer.js
@@ -1,7 +1,7 @@
 var config = require(__dirname + '/../../../config.js');
 var help = require(__dirname + '/../help');
 var log = require(__dirname + '/../log');
-var Passport = require(__dirname + '/../../../../passport/node/src'); // !!! TODO: Replace with NPM
+var Passport = require('@dadi/passport');
 
 var BearerAuthStrategy = function(options) {
   this.config = options;
@@ -17,6 +17,7 @@ BearerAuthStrategy.prototype.getType = function () {
 
 BearerAuthStrategy.prototype.getToken = function (datasource, done) {
   var strategy = datasource.authStrategy.config;
+  var self = this;
 
   Passport({
     issuer: {
@@ -35,9 +36,9 @@ BearerAuthStrategy.prototype.getToken = function (datasource, done) {
     var err = new Error();
     err.name = errorData.title;
     err.message = errorData.detail;
-    err.remoteIp = options.issuer.uri;
-    err.remotePort = options.issuer.port;
-    err.path = options.issuer.endpoint;
+    err.remoteIp = self.config.host;
+    err.remotePort = self.config.port;
+    err.path = self.config.tokenUrl;
 
     return done(err);
   });

--- a/dadi/lib/auth/bearer.js
+++ b/dadi/lib/auth/bearer.js
@@ -1,5 +1,6 @@
-var http = require('http');
+var help = require(__dirname + '/../help');
 var log = require(__dirname + '/../log');
+var Passport = require(__dirname + '/../../../../passport/node/src'); // !!! TODO: Replace with NPM
 
 var BearerAuthStrategy = function(options) {
   this.config = options;
@@ -7,79 +8,38 @@ var BearerAuthStrategy = function(options) {
   this.token = {};
 };
 
-BearerAuthStrategy.prototype.getToken = function(datasource, done) {
+// All auth strategies must announce its type via a `getType()` method,
+// so other components upstream can make decisions accordingly.
+BearerAuthStrategy.prototype.getType = function () {
+  return 'bearer';
+};
 
-  var self = this;
+BearerAuthStrategy.prototype.getToken = function (datasource, done) {
+  var config = datasource.authStrategy.config;
 
-  if (self.token.authToken && self.token.authToken.accessToken) {
-    var now = Math.floor(Date.now() / 1000);
-    // if the token creation date + expiry in seconds is greater
-    // than the current time, we don't need to generate a new token
-    if ((self.token.created_at + self.token.authToken.expiresIn) > now) {
-      return done(null, self.token.authToken.accessToken);
+  Passport({
+    issuer: {
+      uri: (config.protocol || 'http') + '://' + config.host,
+      port: config.port,
+      endpoint: config.tokenUrl
+    },
+    credentials: config.credentials,
+    wallet: 'file',
+    walletOptions: {
+      path: __dirname + '/' + help.generateTokenWalletFilename(config.host, config.port, config.credentials.clientId)
     }
-  }
+  }).then(function (bearerToken) {
+    return done(null, bearerToken);
+  }).catch(function (errorData) {
+    var err = new Error();
+    err.name = errorData.title;
+    err.message = errorData.detail;
+    err.remoteIp = options.issuer.uri;
+    err.remotePort = options.issuer.port;
+    err.path = options.issuer.endpoint;
 
-  log.info({module: 'auth/bearer'}, 'Generating new access token for datasource %s', datasource.name);
-
-  var postData = {
-    clientId : self.config.credentials.clientId,
-    secret : self.config.credentials.secret
-  };
-
-  var options = {
-    hostname: self.config.host,
-    port: self.config.port,
-    path: self.tokenRoute,
-    method: 'POST',
-    agent: new http.Agent({ keepAlive: true }),
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  };
-
-  var req = http.request(options, function(res) {
-    var output = '';
-
-    res.on('data', function(chunk) {
-      output += chunk;
-    });
-
-    res.setTimeout(10);
-
-    res.on('end', function() {
-
-      if (output === '') {
-        var message = 'No token received, invalid credentials for datasource "' + datasource.name + '"';
-        var err = new Error();
-        err.name = 'Datasource authentication';
-        err.message = message;
-        err.remoteIp = options.hostname;
-        err.remotePort = options.port;
-        return done(err);
-      }
-
-      var tokenResponse = JSON.parse(output);
-      self.token.authToken = tokenResponse;
-      self.token.created_at = Math.floor(Date.now() / 1000);
-
-      return done(null, self.token.authToken.accessToken);
-    });
-  });
-
-  req.on('error', function (err) {
-    var message = 'Couldn\'t request accessToken for datasource "' + datasource.name + '"';
-    err.name = 'Datasource authentication';
-    err.message = message;
-    err.remoteIp = options.hostname;
-    err.remotePort = options.port;
     return done(err);
   });
-
-  // write data to request body
-  req.write(JSON.stringify(postData));
-
-  req.end();
 };
 
 module.exports = function (options) {

--- a/dadi/lib/auth/index.js
+++ b/dadi/lib/auth/index.js
@@ -24,7 +24,7 @@ module.exports.getToken = function () {
     },
     wallet: 'file',
     walletOptions: {
-      path: __dirname + '/' + help.generateTokenWalletFilename(config.get('api.host'), config.get('api.port'), config.get('auth.clientId'))
+      path: config.get('paths.tokenWallet') + '/' + help.generateTokenWalletFilename(config.get('api.host'), config.get('api.port'), config.get('auth.clientId'))
     }
   });
 };
@@ -44,7 +44,7 @@ module.exports = function (server) {
       log.info({module: 'auth'}, 'Retrieving access token for "' + req.url + '"');
       help.timer.start('auth');
 
-      self.getToken().then(function (bearerToken) {
+      return self.getToken().then(function (bearerToken) {
         help.timer.stop('auth');
 
         return next();

--- a/dadi/lib/auth/index.js
+++ b/dadi/lib/auth/index.js
@@ -11,23 +11,23 @@ var Passport = require('@dadi/passport');
 
 var self = this;
 
-module.exports.getToken = function () {
-  return Passport({
-    issuer: {
-      uri: config.get('api.protocol') + '://' + config.get('api.host'),
-      port: config.get('api.port'),
-      endpoint: config.get('auth.tokenUrl')
-    },
-    credentials: {
-      clientId: config.get('auth.clientId'),
-      secret: config.get('auth.secret')
-    },
-    wallet: 'file',
-    walletOptions: {
-      path: config.get('paths.tokenWallet') + '/' + help.generateTokenWalletFilename(config.get('api.host'), config.get('api.port'), config.get('auth.clientId'))
-    }
-  });
-};
+// module.exports.getToken = function () {
+//   return Passport({
+//     issuer: {
+//       uri: config.get('api.protocol') + '://' + config.get('api.host'),
+//       port: config.get('api.port'),
+//       endpoint: config.get('auth.tokenUrl')
+//     },
+//     credentials: {
+//       clientId: config.get('auth.clientId'),
+//       secret: config.get('auth.secret')
+//     },
+//     wallet: 'file',
+//     walletOptions: {
+//       path: config.get('paths.tokenWallet') + '/' + help.generateTokenWalletFilename(config.get('api.host'), config.get('api.port'), config.get('auth.clientId'))
+//     }
+//   });
+// };
 
 // This attaches middleware to the passed in app instance
 module.exports = function (server) {
@@ -35,7 +35,7 @@ module.exports = function (server) {
     log.info({module: 'auth'}, 'Retrieving access token for "' + req.url + '"');
     help.timer.start('auth');
 
-    return self.getToken().then(function (bearerToken) {
+    return help.getToken().then(function (bearerToken) {
       help.timer.stop('auth');
 
       return next();

--- a/dadi/lib/auth/index.js
+++ b/dadi/lib/auth/index.js
@@ -4,6 +4,8 @@
 var config = require(__dirname + '/../../../config.js');
 var help = require(__dirname + '/../help');
 var log = require(__dirname + '/../log');
+var mkdirp = require('mkdirp');
+var path = require('path');
 
 var Passport = require(__dirname + '/../../../../passport/node/src'); // !!! TODO: Replace with NPM
 
@@ -14,7 +16,7 @@ module.exports.getToken = function () {
     issuer: {
       uri: config.get('api.protocol') + '://' + config.get('api.host'),
       port: config.get('api.port'),
-      endpoint: config.get('auth.tokenUrl')  
+      endpoint: config.get('auth.tokenUrl')
     },
     credentials: {
       clientId: config.get('auth.clientId'),
@@ -29,25 +31,35 @@ module.exports.getToken = function () {
 
 // This attaches middleware to the passed in app instance
 module.exports = function (server) {
-  server.app.use(function (req, res, next) {
-    log.info({module: 'auth'}, 'Retrieving access token for "' + req.url + '"');
-    help.timer.start('auth');
+  mkdirp(path.resolve(config.get('paths.tokenWallet')), {}, function (err, made) {
+    if (err) {
+      console.log(err);
+    }
 
-    self.getToken().then(function (bearerToken) {
-      help.timer.stop('auth');
+    if (made) {
+      console.log('Token wallet directory created at ' + made);
+    }
 
-      return next();
-    }).catch(function (errorData) {
-      var err = new Error();
-      err.name = errorData.title;
-      err.message = errorData.detail;
-      err.remoteIp = options.issuer.uri;
-      err.remotePort = options.issuer.port;
-      err.path = options.issuer.endpoint;
+    server.app.use(function (req, res, next) {
+      log.info({module: 'auth'}, 'Retrieving access token for "' + req.url + '"');
+      help.timer.start('auth');
 
-      help.timer.stop('auth');
+      self.getToken().then(function (bearerToken) {
+        help.timer.stop('auth');
 
-      return next(err);
+        return next();
+      }).catch(function (errorData) {
+        var err = new Error();
+        err.name = errorData.title;
+        err.message = errorData.detail;
+        err.remoteIp = config.get('api.host');
+        err.remotePort = config.get('api.port');
+        err.path = config.get('auth.tokenUrl');
+
+        help.timer.stop('auth');
+
+        return next(err);
+      });    
     });    
   });
 };

--- a/dadi/lib/auth/index.js
+++ b/dadi/lib/auth/index.js
@@ -1,101 +1,53 @@
 /**
  * @module Auth
  */
-var http = require('http');
-var url = require('url');
-var querystring = require('querystring');
-
 var config = require(__dirname + '/../../../config.js');
 var help = require(__dirname + '/../help');
 var log = require(__dirname + '/../log');
-var token = require(__dirname + '/token');
+
+var Passport = require(__dirname + '/../../../../passport/node/src'); // !!! TODO: Replace with NPM
+
+var self = this;
+
+module.exports.getToken = function () {
+  return Passport({
+    issuer: {
+      uri: config.get('api.protocol') + '://' + config.get('api.host'),
+      port: config.get('api.port'),
+      endpoint: config.get('auth.tokenUrl')  
+    },
+    credentials: {
+      clientId: config.get('auth.clientId'),
+      secret: config.get('auth.secret')
+    },
+    wallet: 'file',
+    walletOptions: {
+      path: __dirname + '/' + help.generateTokenWalletFilename(config.get('api.host'), config.get('api.port'), config.get('auth.clientId'))
+    }
+  });
+};
 
 // This attaches middleware to the passed in app instance
 module.exports = function (server) {
+  server.app.use(function (req, res, next) {
+    log.info({module: 'auth'}, 'Retrieving access token for "' + req.url + '"');
+    help.timer.start('auth');
 
-    var tokenRoute = config.get('auth.tokenUrl') || '/token';
+    self.getToken().then(function (bearerToken) {
+      help.timer.stop('auth');
 
-    // Authorize
-    server.app.use(function (req, res, next) {
+      return next();
+    }).catch(function (errorData) {
+      var err = new Error();
+      err.name = errorData.title;
+      err.message = errorData.detail;
+      err.remoteIp = options.issuer.uri;
+      err.remotePort = options.issuer.port;
+      err.path = options.issuer.endpoint;
 
-        var self = this;
+      help.timer.stop('auth');
 
-        // don't authenticate *.jpg GET requests
-        var path = url.parse(req.url).pathname;
-        if (path.split(".").pop() === 'jpg') return next();
-
-        if (token.authToken.accessToken) {
-          var now = Math.floor(Date.now() / 1000);
-          // if the token creation date + expiry in seconds is greater
-          // than the current time, we don't need to generate a new token
-          if ((token.created_at + token.authToken.expiresIn) > now) {
-            return next();
-          }
-        }
-
-        log.info({module: 'auth'}, 'Generating new access token for "' + req.url + '"');
-        help.timer.start('auth');
-
-        var postData = JSON.stringify({
-          clientId : config.get('auth.clientId'),
-          secret : config.get('auth.secret')
-        });
-
-        var options = {
-          hostname: config.get('api.host'),
-          port: config.get('api.port'),
-          path: tokenRoute,
-          method: 'POST',
-          agent: new http.Agent({ keepAlive: true }),
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        };
-
-        var request = http.request(options, function(res) {
-          var output = '';
-
-          res.on('data', function(chunk) {
-            output += chunk;
-          });
-
-          res.on('end', function() {
-            if (!output) {
-              var err = new Error();
-              var message = 'No token received, invalid credentials.';
-              err.name = 'Authentication';
-              err.message = message;
-              err.remoteIp = options.hostname;
-              err.remotePort = options.port;
-              err.path = options.path;
-              return next(err);
-            }
-
-            var tokenResponse = JSON.parse(output);
-            token.authToken = tokenResponse;
-            token.created_at = Math.floor(Date.now() / 1000);
-
-            help.timer.stop('auth');
-
-            return next();
-          });
-        });
-
-        request.on('error', function(err) {
-          var message = 'Couldn\'t request accessToken';
-          err.name = 'Authentication';
-          err.message = message;
-          err.remoteIp = options.hostname;
-          err.remotePort = options.port;
-
-          help.timer.stop('auth');
-          next(err);
-        });
-
-        // write data to request body
-        request.write(postData);
-
-        request.end();
-    });
-
+      return next(err);
+    });    
+  });
 };

--- a/dadi/lib/auth/index.js
+++ b/dadi/lib/auth/index.js
@@ -7,7 +7,7 @@ var log = require(__dirname + '/../log');
 var mkdirp = require('mkdirp');
 var path = require('path');
 
-var Passport = require(__dirname + '/../../../../passport/node/src'); // !!! TODO: Replace with NPM
+var Passport = require('@dadi/passport');
 
 var self = this;
 
@@ -50,6 +50,6 @@ module.exports = function (server) {
       help.timer.stop('auth');
 
       return next(err);
-    });    
+    });
   });
 };

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -66,26 +66,20 @@ Controller.prototype.attachDatasources = function(done) {
 Controller.prototype.attachEvents = function(done) {
   var self = this;
 
-  this.page.events.forEach(function(eventName) {
-    var e = new Event(self.page.name, eventName, self.options);
-    self.events.push(e);
-  });
-
   // add global events first
   config.get('globalEvents').forEach(function(eventName) {
     var e = new Event(self.page.name, eventName, self.options);
     self.preloadEvents.push(e);
-  });
-
-  // add global events first
-  config.get('globalEvents').forEach(function(eventName) {
-    var e = new Event(self.page.name, eventName, self.options);
-    self.preloadEvents[eventName] = e;
   });
 
   this.page.preloadEvents.forEach(function(eventName) {
     var e = new Event(self.page.name, eventName, self.options);
     self.preloadEvents.push(e);
+  });
+
+  this.page.events.forEach(function(eventName) {
+    var e = new Event(self.page.name, eventName, self.options);
+    self.events.push(e);
   });
 
   done();

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -278,6 +278,8 @@ Server.prototype.loadPaths = function(paths) {
   options.filtersPath = path.resolve(paths.filters || __dirname + '/../../app/utils/filters');
   options.helpersPath = path.resolve(paths.helpers || __dirname + '/../../app/utils/helpers');
 
+  options.tokenWalletsPath = path.resolve(paths.tokenWallets || __dirname + '/../../.wallet');
+
   if (paths.media) options.mediaPath = path.resolve(paths.media);
   if (paths.public) options.publicPath = path.resolve(paths.public);
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "posttest": "./scripts/coverage.js"
   },
   "dependencies": {
+    "@dadi/passport": "^1.0.x",
     "@dadi/status": "git+https://git@github.com/dadi/status.git",
     "async": "^1.4.2",
     "aws-kinesis-writable": "^1.3.1",
@@ -57,6 +58,7 @@
     "istanbul-cobertura-badger": "^1.1.0",
     "kinesalite": "^1.9.0",
     "mocha": "latest",
+    "nock": "^7.7.2",
     "nodeunit": ">=0.5.1",
     "proxyquire": "1.7.3",
     "should": "latest",

--- a/test/acceptance/auth.js
+++ b/test/acceptance/auth.js
@@ -152,11 +152,6 @@ describe.only('Auth', function (done) {
         .expect('content-type', 'text/html')
         .expect(404)
         .end(function (err, res) {
-          console.log('');
-          console.log('** ERR:', err);
-          console.log('--> res:', res);
-          console.log('');
-
           res.text.indexOf('URL not found: The request for URL \'http://invalid.url:' + config.get('api.port') + config.get('auth.tokenUrl') + '\' returned a 404')
                   .should.be.above(-1);
 

--- a/test/app/datasources/car-makes-unchained.json
+++ b/test/app/datasources/car-makes-unchained.json
@@ -21,7 +21,7 @@
       "port": "3000",
       "tokenUrl": "/token",
       "credentials": {
-        "clientId": "rosecombClient",
+        "clientId": "testClient",
         "secret": "superSecret"
       }
     },

--- a/test/pretest.js
+++ b/test/pretest.js
@@ -5,14 +5,14 @@ var colors = require('colors');
 var testConfigPath = './config/config.test.json';
 var testConfigSamplePath = './config/config.test.json.sample';
 
-var testConfigSample = fs.readFileSync(testConfigSamplePath, { encoding: 'utf-8'});
-
 function loadConfig() {
   try {
     var testConfig = fs.readFileSync(testConfigPath, { encoding: 'utf-8'});
   }
   catch (err) {
     if (err.code === 'ENOENT') {
+      var testConfigSample = fs.readFileSync(testConfigSamplePath, { encoding: 'utf-8'});
+
       fs.writeFileSync(testConfigPath, testConfigSample);
       loadConfig();
     }

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -262,7 +262,7 @@ describe('Controller', function (done) {
       var page = getPage();
       controller = Controller(page, options);
       controller.preloadEvents.should.exist;
-      controller.preloadEvents['test_global_event'].should.exist;
+      controller.preloadEvents[0].name.should.eql('test_global_event');
       done();
     })
 


### PR DESCRIPTION
This PR replaces the authentication mechanism with DADI Passport, as per #41.

Bearer tokens for each combination of issuer/clientId are stored in their own separate file, stored under a new hidden folder (`.wallet`), with a filename containing a slug of the uri/port and the client id. 

For example, retrieving a token from `http://api.eb.dev.dadi.technology:80` with the client id of `testClient` will generate the file `.wallet/token.apiebdevdaditechnology80.testclient.json`.

I've added the wallet directory to `config.js` (defaulting to `__dirname + '/.wallet'`) and to [`loadPaths()`](https://github.com/dadi/web/blob/cb9f61a58ab214c84e0a6b5d02d7e4b6c77b04c9/dadi/lib/index.js#L281), so the directory is automatically created.

@jimlambie I'll probably need a hand with the tests. Because the communication with the token issuer is now handled by Passport, it's a bit more difficult to test certain things and some of the tests we have don't really make sense anymore — for example, it's not possible to hijack the request agent with `proxyquire` like we were doing previously.

I've [rewritten some tests](https://github.com/dadi/web/blob/cb9f61a58ab214c84e0a6b5d02d7e4b6c77b04c9/test/acceptance/auth.js#L89-L164) to find things in the HTML error messages instead, but it'd be good to hear your thoughts on the best way to approach this.

Please note that to get this branch working as it stands, you'll need to manually install Passport on a directory named `passport` on the same directory level as Web. We can change this once Passport gets published to npm.

(P.S. Fixed an issue with [`pretest.js`](https://github.com/dadi/web/blob/feature/passport-integration/test/pretest.js#L14) that caused the testing suite to break if `config.test.json.sample` didn't exist. Simply moving the `fs.readFileSync()` call inside the `catch` does the job.)