### PR TITLE
add config option to force a domain redirect

### DIFF
--- a/config.js
+++ b/config.js
@@ -335,6 +335,11 @@ var conf = convict({
       doc: "A set of filenames to remove from URLs. For example ['index.php', 'default.aspx']",
       format: Array,
       default: []
+    },
+    forceDomain: {
+      doc: "The domain to force requests to",
+      format: String,
+      default: ""
     }
   },
   env: {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -11,6 +11,7 @@ var crypto = require('crypto');
 var dust = require('dustjs-linkedin');
 var dustHelpers = require('dustjs-helpers');
 var enableDestroy = require('server-destroy');
+var forceDomain = require('forcedomain');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var path = require('path');
@@ -86,6 +87,12 @@ Server.prototype.start = function (done) {
 
     if (config.get('logging.sentry.dsn') !== "") {
       app.use(raven.middleware.express.requestHandler(config.get('logging.sentry.dsn')));
+    }
+
+    if (config.get('rewrites.forceDomain') !== "") {
+      app.use(forceDomain({
+        hostname: config.get('rewrites.forceDomain')
+      }));
     }
 
     // serve static files (css,js,fonts)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dustjs-linkedin": "^2.7.2",
     "event-stream": "^3.3.1",
     "express-session": "1.12.1",
+    "forcedomain": "0.6.0",
     "htmlstrip-native": "0.1.3",
     "js-beautify": "^1.5.10",
     "json5": "0.2.0",


### PR DESCRIPTION
this allows a setting in config as below which will force redirecting
to the specified domain, e.g. useful to redirect a root domain to www.

```
"rewrites": {
  "forceDomain": "www.example.com"
}
```