### PR TITLE
fix: allow datasource to override protocol

### DIFF
--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -427,7 +427,7 @@ DataHelper.prototype.load = function(done) {
       log.info({module: 'helper'}, "GET datasource '" + self.datasource.schema.datasource.key + "': " + self.options.path);
 
       var request;
-      if (config.get('api.protocol') === 'https') {
+      if (self.options.protocol === 'https') {
         self.options.protocol = 'https:'
         request = https.request(self.options, function(res) {
           self.handleResponse(res, done)


### PR DESCRIPTION
the previous version assumed if the API settings used
https then the datasource calls should too. this commit
allows a datasource to specify it's protocol and have
that override the API setting.