### PR TITLE
feat: paginate helper supports query string & is better tested

### DIFF
--- a/dadi/lib/dust/helpers.js
+++ b/dadi/lib/dust/helpers.js
@@ -385,6 +385,13 @@ function escapeRegExp(string) {
 * Usage:
 * Send in current page, total pages, and a pattern for the path to generate.
 * In the path pattern, use the  dust variable `n` where you want the page number inserted.
+* The helper exposes five different blocks: default/initial, current, prev, next, else & gap.
+* The default/initial/unnamed block is rendered for all steps but the current one, as well as
+* for gaps if the gap block isn't defined. Leave the gap block blank to supress output of gaps.
+* If there is only one page, the {:else} block is the only block that is rendered.
+* When printing the path, if there's a searchstring, use the `|s` filter to
+* disable escaping, as the url will render incorrectly (with `&amp;`'s) otherwise.
+* Please note that this is not safe when printing user input!
 * ```
 * {@paginate page=currentPageNumber totalPages=totalPageCount path="/page/{n}"}
 *   <a href="{path}">{n}</a>
@@ -396,6 +403,20 @@ function escapeRegExp(string) {
 *   <a href="{path}">Next</a>
 * {/paginate}
 * ```
+* If you instead of having the page number in the pathname want it in the querystring, use the `param` option:
+* ```
+* {@paginate page=currentPage totalPages=totalPageCount path="/root" param="page"}
+* - {path|s}
+* {:current}- {path|s} (on)
+* {/paginate}
+* ```
+* Which in the case of example above with `currentPage=2` & `totalPageCount=3` would give the following output:
+* ```
+* - /root
+* - /root?page=2 (on)
+* - /root?page=3
+* ```
+* If the `path` sent in already has a querystring the right param will be set/updated.
 */
 dust.helpers.paginate = function(chunk, context, bodies, params) {
   var err;


### PR DESCRIPTION
Paginate helper is now supports setting the page number as a query parameter, while still working exactly like before when not defining the `param` option.

Additionally a whole slew of tests were written for this feature, as well as covering ground that was previously not tested. This should make future additions or changes much easier to implement correctly.

As suggested by @henriquea 
Att. @jimlambie 