### PR TITLE
Fix check for hasOwnProperty against qs object

### DIFF
--- a/dadi/lib/cache/index.js
+++ b/dadi/lib/cache/index.js
@@ -66,7 +66,7 @@ module.exports = function(server) {
  */
 Cache.prototype.cachingEnabled = function(req) {
   var query = url.parse(req.url, true).query;
-  if (query.hasOwnProperty('json') && query.json !== 'false') {
+  if (query.json) {
     return false;
   }
 


### PR DESCRIPTION
Teeny tiny fix to allow Web to play nicely with Node 6.x.x

Node 6.x.x+ changes qs such that it returns a plain object not a descendent of Object, therefore qs no longer has .hasOwnProperty() nor is this check necessary (nor should this check have been necessary previously as qs's prototype should not be fussed with). 

As far as I can tell from tests and local testing this is the only issue preventing Web from running on the latest Node (v6.2.1).