### PR TITLE
feat: use a datasource as the main htaccess style rewrites

### DIFF
--- a/config.js
+++ b/config.js
@@ -317,6 +317,11 @@ var conf = convict({
       format: String,
       default: ""
     },
+    loadDatasourceAsFile: {
+      doc: "",
+      format: Boolean,
+      default: false
+    },
     path: {
       doc: "",
       format: String,

--- a/dadi/lib/controller/router.js
+++ b/dadi/lib/controller/router.js
@@ -31,6 +31,7 @@ var Router = function (server, options) {
 
   this.rewritesFile = config.get('rewrites.path') === '' ? null : path.resolve(config.get('rewrites.path'));
   this.rewritesDatasource = config.get('rewrites.datasource');
+  this.loadDatasourceAsFile = config.get('rewrites.loadDatasourceAsFile');
 
   this.server = server;
 
@@ -57,26 +58,54 @@ Router.prototype.loadRewrites = function(options, done) {
 
   self.rules = [];
 
-  if (!self.rewritesFile) return done();
+  if (self.rewritesDatasource && self.loadDatasourceAsFile) {
+    // Get the rewritesDatasource
+    var DadiAPI = require('@dadi/api-wrapper')
+    var datasource = new Datasource(self.rewritesDatasource, self.rewritesDatasource, this.options, function(err, ds) {
+      if (err) {
+        log.error({module: 'router'}, err);
+      }
 
-  var stream = fs.createReadStream(self.rewritesFile, {encoding: 'utf8'});
+      var endpointParts = ds.source.endpoint.split('/')
 
-  stream.pipe(es.split("\n"))
-        .pipe(es.mapSync(function (data) {
-          if (data !== "") rules.push(data);
+      var api = new DadiAPI({
+        uri: config.get('api.protocol') + '://' + config.get('api.host'),
+        port: config.get('api.port'),
+        credentials: {
+          clientId: config.get('auth.clientId'),
+          secret: config.get('auth.secret')
+        },
+        version: endpointParts[0],
+        database: endpointParts[1]
+      })
+
+      // Get redirects from API collection
+      api.in(self.rewritesDatasource).find().then(function (response) {
+        _.each(response.results, function(rule) {
+          self.rules.push(rule.rule + ' ' + rule.replacement + ' ' + '[R=' + rule.redirectType + ',L]')
         })
-  );
+      })
+    })
+  }
+  else if (self.rewritesFile) {
+    var stream = fs.createReadStream(self.rewritesFile, {encoding: 'utf8'});
 
-  stream.on('error', function (err) {
-    log.error({module: 'router'}, 'No rewrites loaded, file not found (' + self.rewritesFile + ')');
-    done(err);
-  });
+    stream.pipe(es.split("\n"))
+          .pipe(es.mapSync(function (data) {
+            if (data !== "") rules.push(data);
+          })
+    );
 
-  stream.on('end', function() {
-    self.rules = rules.slice(0);
-    done(null);
-  });
+    stream.on('error', function (err) {
+      log.error({module: 'router'}, 'No rewrites loaded, file not found (' + self.rewritesFile + ')');
+      done(err);
+    });
 
+    stream.on('end', function() {
+      self.rules = rules.slice(0);
+      done(null);
+    });
+  }
 }
 
 /**
@@ -238,7 +267,7 @@ module.exports = function (server, options) {
 
       log.debug({module: 'router'}, '[Router] processing: ' + req.url);
 
-      if (!server.app.Router.rewritesDatasource || server.app.Router.rewritesDatasource === '') return next();
+      if (!server.app.Router.rewritesDatasource || server.app.Router.loadDatasourceAsFile || server.app.Router.rewritesDatasource === '') return next();
 
       var datasource = new Datasource('rewrites', server.app.Router.rewritesDatasource, options, function(err, ds) {
 

--- a/dadi/lib/controller/router.js
+++ b/dadi/lib/controller/router.js
@@ -81,8 +81,11 @@ Router.prototype.loadRewrites = function(options, done) {
 
       // Get redirects from API collection
       api.in(self.rewritesDatasource).find().then(function (response) {
+        var idx = 0
         _.each(response.results, function(rule) {
           self.rules.push(rule.rule + ' ' + rule.replacement + ' ' + '[R=' + rule.redirectType + ',L]')
+          idx++
+          if (idx === response.results.length) return done(null)
         })
       })
     })
@@ -105,6 +108,9 @@ Router.prototype.loadRewrites = function(options, done) {
       self.rules = rules.slice(0);
       done(null);
     });
+  }
+  else {
+    done(null);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "posttest": "./scripts/coverage.js"
   },
   "dependencies": {
+    "@dadi/api-wrapper": "^1.1.0",
     "@dadi/passport": "^1.0.x",
     "@dadi/status": "git+https://git@github.com/dadi/status.git",
     "async": "^1.4.2",

--- a/test/help.js
+++ b/test/help.js
@@ -1,12 +1,3 @@
-/*
-
-TO D)
-datasources
- - chained, param
- - chained, query
-
- */
-
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
@@ -119,6 +110,7 @@ module.exports.startServer = function(pages, done) {
 
   Server.start(function() {
     setTimeout(function() {
+
       pages.forEach(function(page) {
         // create a handler for requests to this page
         var controller = Controller(page, options);

--- a/test/unit/router.js
+++ b/test/unit/router.js
@@ -230,6 +230,7 @@ describe('Router', function (done) {
     it('should redirect to new location if the current request URL is found in a datasource query result', function(done) {
       config.set('api.enabled', false);
       config.set('allowJsonView', true);
+      config.set('loadDatasourceAsFile', false);
       config.set('rewrites.datasource', 'redirects');
 
       var page = getPage();


### PR DESCRIPTION
This PR does two things:

1) adds @dadi/api-wrapper as a dependency, the first step towards relying on it completely for data loading from the API layer
2) introduces a new config property `loadDatasourceAsFile` which when `true` will load the datasource specified at `datasource` as the rewrite rules