### PR TITLE
Error template

### DIFF
--- a/config.js
+++ b/config.js
@@ -97,7 +97,7 @@ var conf = convict({
   },
   caching: {
     ttl: {
-      doc: "",
+      doc: "The time, in seconds, after which cached data is considered stale",
       format: Number,
       default: 300
     },

--- a/dadi/lib/api/index.js
+++ b/dadi/lib/api/index.js
@@ -209,22 +209,23 @@ function onError(api) {
 
     log.error({module: 'api'}, err);
 
-    var message = "<html><head><title>DADI Web - 500 Internal Server Error</title></head>";
-    message += "<body>";
-    message += "<h1>Internal Server Error</h1>";
-    message += "<p>The server encountered an internal error or misconfiguration and was unable to complete your request.</p>";
+    var data = {
+      statusCode: err.statusCode || 500,
+      code: err.name,
+      message: err.message,
+      stack : err.stack.split('\n')
+    }
 
-    // The error id is attached to `res.sentry` to be returned and optionally displayed to the user for support.
-    if (res.sentry) message += "<p>This error has been logged and the development team notified. The unique ID associated with this error is <b>" + res.sentry + "</b>.</p>";
-
-    message += "<blockquote>";
-    message += "<pre>" + err.stack.toString(); + "</pre>";
-    message += "</blockquote>";
-    message += "</body></html>";
-
-    res.statusCode = 500;
-    res.setHeader('Content-Type', 'text/html');
-    res.end(message);
+    var path = _.findWhere(api.paths, { path: '/error' });
+    if (path) {
+      req.error = data;
+      path.handler(req, res);
+    }
+    else {
+      res.statusCode = 500;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(data, null, 2));
+    }
   };
 }
 

--- a/dadi/lib/api/index.js
+++ b/dadi/lib/api/index.js
@@ -200,14 +200,14 @@ module.exports.Api = Api;
 function onError(api) {
   return function (err, req, res, next) {
 
-    if (res.finished) return;
+    if (res.finished) return
 
     if (config.get('env') === 'development') {
-      console.log();
-      console.log(err.stack.toString());
+      console.log()
+      console.log(err.stack.toString())
     }
 
-    log.error({module: 'api'}, err);
+    log.error({module: 'api'}, err)
 
     var data = {
       statusCode: err.statusCode || 500,
@@ -216,17 +216,22 @@ function onError(api) {
       stack : err.stack.split('\n')
     }
 
-    var path = _.findWhere(api.paths, { path: '/error' });
+    // look for a loaded path that matches the error code
+    var path = _.findWhere(api.paths, { path: '/' + data.statusCode })
+    // fallback to a generic /error path
+    if (!path) path = _.findWhere(api.paths, { path: '/error' })
+
     if (path) {
-      req.error = data;
-      path.handler(req, res);
+      req.error = data
+      path.handler(req, res)
     }
     else {
-      res.statusCode = 500;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify(data, null, 2));
+      // no page found to display the error, output raw data
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify(data, null, 2))
     }
-  };
+  }
 }
 
 // return a 404

--- a/dadi/lib/api/index.js
+++ b/dadi/lib/api/index.js
@@ -223,6 +223,7 @@ function onError(api) {
 
     if (path) {
       req.error = data
+      res.statusCode = data.statusCode
       path.handler(req, res)
     }
     else {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -112,6 +112,8 @@ Controller.prototype.buildInitialViewData = function(req) {
   // add query params (params from the querystring, e.g. /reviews?page=2);
   _.extend(data.params, data.query);
 
+  if (req.error) data.error = req.error;
+
   // add id component from the request
   if (req.params.id) data.id = decodeURIComponent(req.params.id);
 

--- a/test/acceptance/app.js
+++ b/test/acceptance/app.js
@@ -156,9 +156,12 @@ describe('Application', function(done) {
 
       client
       .get('/categories/Crime')
-      .expect('content-type', 'text/html')
+      .expect('content-type', 'application/json')
       .expect(500)
-      .end(done);
+      .end(function(err, res) {
+        //console.log(res.body)
+        done()
+      });
     });
   });
 


### PR DESCRIPTION
This PR introduces the ability to specify dust templates on a per-error code basis. If, on error, the app finds a path at, for e.g. /500, it will load that instead of showing the normal error screen. 

The data object is populated with an `error` object containing detail about the error including statusCode and stacktrace

Close #46 