### PR TITLE
Add pagination variable

### DIFF
--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -174,7 +174,6 @@ Datasource.prototype.processDatasourceParameters = function (schema, uri) {
 
 Datasource.prototype.processRequest = function (datasource, req) {
 
-  var self = this;
   var originalFilter = _.clone(this.schema.datasource.filter);
   var query = url.parse(req.url, true).query;
 
@@ -193,9 +192,15 @@ Datasource.prototype.processRequest = function (datasource, req) {
   // if the current datasource matches the page name
   // add some params from the query string or request params
   if ((this.page.name && datasource.indexOf(this.page.name) >= 0) || this.page.passFilters) {
+    var requestParamsPage = this.requestParams.find((obj) => {
+      return (obj.filter === 'page') && obj.param
+    })
 
     // handle pagination param
-    this.schema.datasource.page = query.page || req.params.page || 1;
+    this.schema.datasource.page = query.page ||
+                                  (requestParamsPage && req.params[requestParamsPage]) ||
+                                  req.params.page ||
+                                  1;
 
     // add an ID filter if it was present in the querystring
     // either as http://www.blah.com?id=xxx or via a route parameter e.g. /books/:id
@@ -226,7 +231,7 @@ Datasource.prototype.processRequest = function (datasource, req) {
   // in the querystring's request params e.g. /car-reviews/:make/:model
   // NB don't replace a property that already exists
   _.each(this.requestParams, function(obj) {
-    if (req.params.hasOwnProperty(obj.param)) {
+    if (obj.field && req.params.hasOwnProperty(obj.param)) {
       if (obj.type == "Number") {
         this.schema.datasource.filter[obj.field] = Number(req.params[obj.param]);
       } else {

--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -193,7 +193,7 @@ Datasource.prototype.processRequest = function (datasource, req) {
   // add some params from the query string or request params
   if ((this.page.name && datasource.indexOf(this.page.name) >= 0) || this.page.passFilters) {
     var requestParamsPage = this.requestParams.find((obj) => {
-      return (obj.filter === 'page') && obj.param
+      return (obj.queryParam === 'page') && obj.param
     })
 
     // handle pagination param

--- a/test/unit/datasource.js
+++ b/test/unit/datasource.js
@@ -493,6 +493,35 @@ describe('Datasource', function (done) {
       done();
     });
 
+    it('should use page from requestParams when constructing the endpoint', function (done) {
+      var name = 'car-makes';
+      var schema = help.getPageSchema();
+      var p = page(name, schema);
+      var dsName = 'car-makes';
+      var options = help.getPathOptions();
+      var dsSchema = help.getSchemaFromFile(options.datasourcePath, dsName);
+      sinon.stub(datasource.Datasource.prototype, "loadDatasource").yields(null, dsSchema);
+
+      // add type
+      dsSchema.datasource.requestParams[0].type = 'Number'
+
+      // add page
+      dsSchema.datasource.requestParams.push({ param: 'page', queryParam: 'page' })
+
+      var params = { "make": "1337", "page": 3 };
+      var req = { params: params, url: '/1.0/cars/makes/3' };
+
+      var ds = datasource(p, dsName, options, function() {});
+
+      datasource.Datasource.prototype.loadDatasource.restore();
+
+      ds.processRequest(dsName, req);
+
+      ds.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=3&filter={"name":1337}&fields={"name":1,"_id":0}&sort={"name":1}');
+
+      done();
+    });
+
     it('should pass cache param to the endpoint', function (done) {
       var name = 'test';
       var schema = help.getPageSchema();


### PR DESCRIPTION
This PR addresses #62 by extending `requestParams` to allow mapping a URL parameter to an API filter other than `filter`.

Currently, `requestParams` is defined as an array of `param`/`field` pair (where `param` matches a URL parameter and `field` is a field to be included in API's `filter`):

```json
"requestParams": [
	{"param": "name", "field": "name"}
]
```

This PR allows `requestParams` to define objects with a `filter` parameter (instead of `field`), mapping the value of the URL parameter directly to that filter in API. At the moment it supports only `page`, but can easily be extended to override other filters.

```json
"requestParams": [
	{"param": "page", "filter": "page"}
]
```

This makes it possible to have pagination with http://site.com/page/2, etc.

If you're happy with this approach, I can add some tests. 👋 

/cc @abovebored @jimlambie.