### PR TITLE
Feature: abstract ssl errors

### DIFF
--- a/dadi/lib/api/index.js
+++ b/dadi/lib/api/index.js
@@ -59,7 +59,23 @@ var Api = function () {
       serverOptions.ca = readFileSyncSafe(caPath)
     }
 
-    this.serverInstance = https.createServer(serverOptions, this.listener)
+    // we need to catch any errors resulting from bad parameters
+    // such as incorrect passphrase or no passphrase provided
+    try {
+      this.serverInstance = https.createServer(serverOptions, this.listener)
+    } catch (ex) {
+      var exPrefix = 'error starting https server: '
+      switch (ex.message) {
+        case 'error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt':
+          throw new Error(exPrefix + 'incorrect ssl passphrase')
+          break;
+        case 'error:0906A068:PEM routines:PEM_do_header:bad password read':
+          throw new Error(exPrefix + 'required ssl passphrase not provided')
+          break;
+        default:
+          throw new Error(exPrefix + ex.message)
+      }
+    }
   } else {
     // default to http
     this.serverInstance = http.createServer(this.listener)

--- a/test/acceptance/routing.js
+++ b/test/acceptance/routing.js
@@ -374,7 +374,7 @@ describe('Routing', function(done) {
       try {
         help.startServer(help.setUpPages(), () => {})
       } catch (ex) {
-        ex.message.should.eql('error:0906A068:PEM routines:PEM_do_header:bad password read')
+        ex.message.should.eql('error starting https server: required ssl passphrase not provided')
       }
 
       done()
@@ -389,7 +389,7 @@ describe('Routing', function(done) {
       try {
         help.startServer(help.setUpPages(), () => {})
       } catch (ex) {
-        ex.message.should.eql('error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt')
+        ex.message.should.eql('error starting https server: incorrect ssl passphrase')
       }
 
       done()


### PR DESCRIPTION
### Does this resolve an issue?
No GH issue for this.

Simply abstracts away specific SSL errors and provides friendlier error messages. Acceptance tests updated too.

### Who should review this pull request?
@jimlambie if you would be so kind

### Testing

```
248 passing (13s)
24 pending

== Coverage summary ===============================
Statements   : 65.21% ( 1685/2584 )
Branches     : 51.59% ( 617/1196 )
Functions    : 65.62% ( 271/413 )
Lines        : 66.52% ( 1647/2476 )
================================================
```

🍰 