### PR TITLE
Feature: wordpress provider

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,7 +11,7 @@ var conf = convict({
       default: "DADI Web (Repo Default)"
     }
   },
-	server: {
+  server: {
     host: {
       doc: "The IP address the web application will run on",
       format: '*',
@@ -70,7 +70,7 @@ var conf = convict({
       env: "SSL_INTERMEDIATE_CERTIFICATE_PATHS"
     }
   },
-	api: {
+  api: {
     host: {
       doc: "The IP address the DADI API application runs on",
       format: '*',
@@ -93,7 +93,7 @@ var conf = convict({
     }
   },
   auth: {
-  	tokenUrl: {
+    tokenUrl: {
       doc: "",
       format: String,
       default: "/token"
@@ -212,7 +212,7 @@ var conf = convict({
     }
   },
   dust: {
-  	cache: {
+    cache: {
       doc: "If true, compiled templates are saved to the Dust cache. Recommended setting: true",
       format: Boolean,
       default: true
@@ -250,7 +250,7 @@ var conf = convict({
     }
   },
   logging: {
-  	enabled: {
+    enabled: {
       doc: "If true, logging is enabled using the following settings.",
       format: Boolean,
       default: true

--- a/config.js
+++ b/config.js
@@ -162,6 +162,14 @@ var conf = convict({
       env: "TWITTER_ACCESS_TOKEN_SECRET"
     }
   },
+  wordpress: {
+    bearerToken: {
+      doc: "A pregenerated oauth access bearer token",
+      format: String,
+      default: "",
+      env: "WORDPRESS_BEARER_TOKEN"
+    }
+  },
   caching: {
     ttl: {
       doc: "The time, in seconds, after which cached data is considered stale",

--- a/dadi/lib/providers/wordpress.js
+++ b/dadi/lib/providers/wordpress.js
@@ -1,0 +1,155 @@
+'use strict'
+
+const _ = require('underscore')
+const Purest = require('purest')
+const log = require(__dirname + '/../log')
+const config = require(__dirname + '/../../../config.js')
+const DatasourceCache = require(__dirname + '/../cache/datasource')
+
+const WordPressProvider = function () {}
+
+/**
+ * initialise - initialises the datasource provider
+ *
+ * @param  {obj} datasource - the datasource to which this provider belongs
+ * @param  {obj} schema - the schema that this provider works with
+ * @return {void}
+ */
+WordPressProvider.prototype.initialise = function initialise(datasource, schema) {
+  this.datasource = datasource
+  this.schema = schema
+  this.setAuthStrategy()
+  this.wordpressApi = new Purest({
+    provider: 'wordpress',
+    version: 'v1.1'
+  })
+}
+
+
+/**
+ * buildEndpoint
+ *
+ * @param  {obj} req - web request object
+ * @return {void}
+ */
+WordPressProvider.prototype.buildEndpoint = function buildEndpoint(req) {
+  const endpointParams = this.schema.datasource.endpointParams || []
+  const endpoint = this.schema.datasource.source.endpoint
+
+  this.endpoint = endpoint
+
+  // make sure that we interpolate any dynamic parts to the endpoint
+  if (endpointParams.length > 0) {
+    endpointParams.forEach((element, index, array) => {
+      if (element.param && req.params[element.param]) {
+        this.endpoint = this.endpoint.replace(`\$${element.field}`, req.params[element.param])
+      }
+    })
+  }
+}
+
+/**
+ * buildQueryParams
+ *
+ * @return {obj} query params to pass to the wordpress api
+ */
+WordPressProvider.prototype.buildQueryParams = function buildQueryParams() {
+  const params = {}
+  const datasource = this.schema.datasource
+
+  params.count = datasource.count
+  params.fields = ''
+
+  if (_.isArray(datasource.fields))
+    params.fields = datasource.fields.join(',')
+  else if (_.isObject(datasource.fields))
+    params.fields = Object.keys(datasource.fields).join(',')
+
+  for (let f in datasource.filter) {
+    params[f] = datasource.filter[f]
+  }
+
+  return params
+}
+
+/**
+ * load - loads data form the datasource
+ *
+ * @param  {string} requestUrl - url of the web request (not used)
+ * @param  {fn} done - callback on error or completion
+ * @return {void}
+ */
+WordPressProvider.prototype.load = function load(requestUrl, done) {
+  try {
+    const queryParams = this.buildQueryParams()
+
+    this.cacheKey = [this.endpoint, encodeURIComponent(JSON.stringify(this.schema.datasource))].join('+')
+    this.dataCache = new DatasourceCache(this.datasource)
+
+    this.dataCache.getFromCache((cachedData) => {
+      if (cachedData) return done(null, cachedData)
+
+      this.wordpressApi.query()
+        .select(this.endpoint)
+        .where(queryParams)
+        .auth(this.bearerToken || null)
+        .request((err, res, body) => {
+          if (err) return done(err, null)
+          this.processOutput(res, body, done)
+        })
+    })
+  } catch (ex) {
+    done(ex, null)
+  }
+}
+
+/**
+ * processOutput
+ *
+ * @param  {response} res
+ * @param  {string} data
+ * @param  {fn} done
+ * @return {void}
+ */
+WordPressProvider.prototype.processOutput = function processOutput(res, data, done) {
+  // if the error is anything other than Success or Bad Request, error
+  if (res.statusCode && !/200|400/.exec(res.statusCode)) {
+    const err = new Error()
+    const info = `${res.statusMessage} (${res.statusCode}): ${this.endpoint}`
+
+    err.message = `Datasource "${this.datasource.name}" failed. ${info}`
+    if (data) err.message += '\n' + data
+
+    log.error({ module: 'helper' }, info)
+    return done(err)
+  }
+
+  if (res.statusCode === 200) {
+    this.dataCache.cacheResponse(JSON.stringify(data), () => {})
+  }
+
+  return done(null, data)
+}
+
+/**
+ * processRequest - called on every request, call buildEndpoint
+ *
+ * @param  {obj} req - web request object
+ * @return {void}
+ */
+WordPressProvider.prototype.processRequest = function processRequest(req) {
+  this.buildEndpoint(req)
+}
+
+/**
+ * setAuthStrategy
+ *
+ * @return {void}
+ */
+WordPressProvider.prototype.setAuthStrategy = function setAuthStrategy() {
+  const auth = this.schema.datasource.auth
+
+  this.bearerToken = auth && auth.bearerToken || config.get('wordpress.bearerToken')
+}
+
+module.exports = WordPressProvider


### PR DESCRIPTION
### Words
This is the first initial version of a WordPress provider. There are some things that aren't working like `count` and `filter`. Initially I thought that Purest's `where` function would convert these to queryString as it's supposed to but it doesn't appear to do that.

Will continue to look into ways that we can do this. Purest recently went from 2.X to 3.X so perhaps an upgrade may help fix things.

I've been using my demo stack for implementation, there you can see [datasources](https://github.com/adamkdean/dadi-demo-stack/tree/feature/extensible_datasource/web/app/datasources) and [pages](https://github.com/adamkdean/dadi-demo-stack/tree/feature/extensible_datasource/web/app/pages).

I've only put together a simple example of list blog posts, and then retrieve blog post once you click on it. Like we discussed in https://github.com/dadi/web/issues/52, getting a token via OAuth 2 isn't viable server-side so for authentication purposes you can simply define a bearer token, but for most things, a token isn't required for the WordPress public API.

### Endpoint params
Whilst looking at this I felt like there was a bit of a restriction on the endpoints. The WordPress API makes use of API routes and we really needed a way to have dynamic endpoints. Look at this example below (edited for brevity):

```json
{
  "datasource": {
    "key": "wordpress-post",
    "name": "WordPress single post datasource",
    "source": {
      "type": "wordpress",
      "endpoint": "sites/neversettleblog.wordpress.com/posts/slug:$post_slug"
    },
    "endpointParams": [
      {
        "param": "slug",
        "field": "post_slug"
      }
    ],
    "requestParams": []
  }
}
```

I've had to go for dollar variable name as WP uses colons as delimiters in their URLs and I don't really want to start using escape-slashes a la `sites/neversettleblog.wordpress.com/posts/slug\::post_slug`.

Thoughts on this? Should this be moved up from WordPressProvider to all providers?

### Review

What do you think, @jimlambie ?

Hope this is something around what you were looking for, @abovebored?
