### PR TITLE
Fix: transport security

### DIFF
--- a/config.js
+++ b/config.js
@@ -450,6 +450,11 @@ var conf = convict({
       doc: 'If true, trusts the values specified in X-Forwarded-* headers, such as protocol and client IP address',
       format: '*',
       default: true
+    },
+    transportSecurity: {
+      doc: 'If true, requires requests to be secure. Overridden if server.protocol is set to https.',
+      format: '*',
+      default: false
     }
   },
   env: {

--- a/dadi/lib/api/middleware.js
+++ b/dadi/lib/api/middleware.js
@@ -114,13 +114,13 @@ middleware.setUpRequest = function () {
 }
 
 middleware.transportSecurity = function () {
-  function securityEnabled() {
+  function securityEnabled () {
     var transportSecurity = config.get('security.transportSecurity')
     var protocol = config.get('server.protocol')
     return protocol === 'https' || transportSecurity
   }
 
-  function redirect(req, res, scheme) {
+  function redirect (req, res, scheme) {
     var location = scheme + '//' + req.headers.host + req.url
     res.writeHead(301, {
       Location: location

--- a/dadi/lib/api/middleware.js
+++ b/dadi/lib/api/middleware.js
@@ -114,14 +114,13 @@ middleware.setUpRequest = function () {
 }
 
 middleware.transportSecurity = function () {
-  var protocol = config.get('server.protocol') || 'http'
-  var scheme = protocol === 'https' ? HTTPS : HTTP
-
-  function securityEnabled () {
-    return scheme === HTTPS
+  function securityEnabled() {
+    var transportSecurity = config.get('security.transportSecurity')
+    var protocol = config.get('server.protocol')
+    return protocol === 'https' || transportSecurity
   }
 
-  function redirect (req, res, scheme) {
+  function redirect(req, res, scheme) {
     var location = scheme + '//' + req.headers.host + req.url
     res.writeHead(301, {
       Location: location


### PR DESCRIPTION
Close #116 

- Adds `security.transportSecurity` configuration option.
- Fixes transport security middleware.

See issue for more a detailed analysis.