### PR TITLE
Disable API by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -95,7 +95,7 @@ var conf = convict({
     enabled: {
       doc: 'Determines whether this web instance requires access to the API',
       format: Boolean,
-      default: true
+      default: false
     }
   },
   auth: {

--- a/config/config.development.json.sample
+++ b/config/config.development.json.sample
@@ -8,7 +8,7 @@
   },
   "cluster": false,
   "api": {
-    "enabled": "false",
+    "enabled": false,
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.development.json.sample
+++ b/config/config.development.json.sample
@@ -8,6 +8,7 @@
   },
   "cluster": false,
   "api": {
+    "enabled": "false",
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.https.json.sample
+++ b/config/config.https.json.sample
@@ -11,6 +11,7 @@
     "sslCertificatePath": "ssl/cert.pem"
   },
   "api": {
+    "enabled": "false",
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.https.json.sample
+++ b/config/config.https.json.sample
@@ -11,7 +11,7 @@
     "sslCertificatePath": "ssl/cert.pem"
   },
   "api": {
-    "enabled": "false",
+    "enabled": false,
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.production.json.sample
+++ b/config/config.production.json.sample
@@ -7,6 +7,7 @@
     "port": 3001
   },
   "api": {
+    "enabled": "false",
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.production.json.sample
+++ b/config/config.production.json.sample
@@ -7,7 +7,7 @@
     "port": 3001
   },
   "api": {
-    "enabled": "false",
+    "enabled": false,
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.qa.json.sample
+++ b/config/config.qa.json.sample
@@ -7,6 +7,7 @@
     "port": 3001
   },
   "api": {
+    "enabled": "false",
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.qa.json.sample
+++ b/config/config.qa.json.sample
@@ -7,7 +7,7 @@
     "port": 3001
   },
   "api": {
-    "enabled": "false",
+    "enabled": false,
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -8,7 +8,7 @@
   },
   "cluster": false,
   "api": {
-    "enabled": "false",
+    "enabled": false,
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -8,6 +8,7 @@
   },
   "cluster": false,
   "api": {
+    "enabled": "false",
     "host": "127.0.0.1",
     "port": 3000
   },

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -752,7 +752,7 @@ function onListening (e) {
     if (config.get('api.enabled') === true) {
       startText += '  API:         '.green + extraPadding + config.get('api.host') + ':' + config.get('api.port') + '\n'
     } else {
-      startText += '  API:         '.green + extraPadding + 'Not found'.red + '\n'
+      startText += '  API:         '.green + extraPadding + 'Disabled'.red + '\n'
       startText += '  ----------------------------\n'
     }
 

--- a/test/acceptance/routing.js
+++ b/test/acceptance/routing.js
@@ -50,6 +50,7 @@ describe('Routing', function (done) {
     //scope = nock(apiHost).post('/token').reply(200, { accessToken: 'xx' })
     var configUpdate = {
       server: {
+        enabled: true,
         host: '127.0.0.1',
         port: 5000
       }


### PR DESCRIPTION
I propose disabling the API configuration block by default. First time users who are interested in exploring Web's features experience an error on first load related to an API not being present at the location specified in the `config.json`. This way you can also keep the config file cleaner by removing the `api` block all together if you don't need it.

Users who are actively connecting Web to API will have less ambiguity by having to explicitly set `"enabled": true`.

Additionally includes an update of the message in the console to indicate when `config.api.enabled === false` to say `Disabled` rather than `Not found`. It's confused me a few times as to what exactly was happening as it suggests it is _looking_ for the API but not finding it (404 or 401 error) rather than it not even trying.