### PR TITLE
Rebuild chained datasource endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="http://52.209.207.148/assets/products/dadi-web-full.png" alt="DADI Web" height="65"/>
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/web.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/web)
-[![coverage](https://img.shields.io/badge/coverage-64%25-yellow.svg?style=flat-square)](https://github.com/dadi/web)
+[![coverage](https://img.shields.io/badge/coverage-66%25-yellow.svg?style=flat-square)](https://github.com/dadi/web)
 [![Build Status](https://travis-ci.org/dadi/web.svg?branch=master)](https://travis-ci.org/dadi/web)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)

--- a/dadi/lib/providers/remote.js
+++ b/dadi/lib/providers/remote.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _ = require('underscore')
+const debug = require('debug')('web:provider:remote')
 const url = require('url')
 const http = require('http')
 const https = require('https')
@@ -165,6 +166,7 @@ RemoteProvider.prototype.keepAliveAgent = function keepAliveAgent (protocol) {
  * @return {void}
  */
 RemoteProvider.prototype.load = function (requestUrl, done) {
+  debug('load %s', this.endpoint)
   const self = this
 
   this.requestUrl = requestUrl
@@ -213,9 +215,9 @@ RemoteProvider.prototype.load = function (requestUrl, done) {
 /**
  * processDatasourceParameters - adds querystring parameters to the datasource endpoint using properties defined in the schema
  *
- * @param  {json} schema - the datasource schema
+ * @param  {Object} schema - the datasource schema
  * @param  {type} uri - the original datasource endpoint
- * @return {string} uri with query string appended
+ * @returns {string} uri with query string appended
  */
 RemoteProvider.prototype.processDatasourceParameters = function processDatasourceParameters (schema, uri) {
   let query = '?'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "init": "validate-commit-msg",
     "start": "node ./main.js",
-    "test": "standard && env NODE_ENV=test ./node_modules/.bin/istanbul cover -x '**/workspace/**' -x '**/app/**' --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha test -- --require babel-register",
+    "test": "standard && env NODE_ENV=test ./node_modules/.bin/istanbul cover -x '**/workspace/**' -x '**/app/**' --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha test",
     "posttest": "node ./scripts/coverage.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "snyk-protect": "snyk protect",
@@ -59,14 +59,14 @@
     "serve-favicon": "^2.3.0",
     "serve-static": "^1.10.0",
     "server-destroy": "1.0.1",
+    "snyk": "^1.25.0",
     "stack-trace": "latest",
     "toobusy-js": "^0.4.2",
     "uglify-js": "^2.6.2",
     "underscore": "~1.6.0",
     "underscore.string": "^3.2.2",
     "validate-commit-message": "^3.0.1",
-    "wildcard": "^1.1.2",
-    "snyk": "^1.25.0"
+    "wildcard": "^1.1.2"
   },
   "devDependencies": {
     "babel-register": "^6.18.0",

--- a/test/app/datasources/car-makes.json
+++ b/test/app/datasources/car-makes.json
@@ -39,8 +39,8 @@
     "chained": {
       "datasource": "global",
       "outputParam": {
-      "param": "results.0.id",
-      "field": "makeId"
+        "param": "results.0.id",
+        "field": "_id"
       }
     },
     "requestParams": [

--- a/test/app/datasources/global.json
+++ b/test/app/datasources/global.json
@@ -1,0 +1,18 @@
+{
+  "datasource": {
+    "key": "global",
+    "name": "Global datasource",
+    "source": {
+      "type": "remote",
+      "protocol": "http",
+      "host": "127.0.0.1",
+      "port": "3000",
+      "endpoint": "1.0/system/all"
+    },
+    "paginate": true,
+  	"count": 20,
+  	"sort": { "name":1 },
+  	"search": {},
+    "filter": {}
+  }
+}


### PR DESCRIPTION
Chained datasources are not having their endpoints rebuilt after applying results from their chainee, and before calling `load()`

Fix #123