### PR TITLE
Add requestParams to datasource endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="http://52.209.207.148/assets/products/dadi-web-full.png" alt="DADI Web" height="65"/>
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/web.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/web)
-[![coverage](https://img.shields.io/badge/coverage-67%25-yellow.svg?style=flat-square)](https://github.com/dadi/web)
+[![coverage](https://img.shields.io/badge/coverage-67%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/web)
 [![Build Status](https://travis-ci.org/dadi/web.svg?branch=master)](https://travis-ci.org/dadi/web)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)

--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -21,44 +21,38 @@ var Datasource = function (page, datasource, options) {
 }
 
 Datasource.prototype.init = function (callback) {
-  var self = this
-
-  this.loadDatasource(function (err, schema) {
+  this.loadDatasource((err, schema) => {
     if (err) {
       return callback(err)
     }
 
-    self.schema = schema
-    self.source = schema.datasource.source
-    self.schema.datasource.filter = self.schema.datasource.filter || {}
-    self.originalFilter = _.clone(self.schema.datasource.filter)
+    this.schema = schema
+    this.source = schema.datasource.source
+    this.schema.datasource.filter = this.schema.datasource.filter || {}
+    this.originalFilter = _.clone(this.schema.datasource.filter)
 
-    if (!self.source.type) {
-      self.source.type = 'remote'
+    if (!this.source.type) {
+      this.source.type = 'remote'
     }
 
-    // if (self.source.type === 'static') {
-    //   callback(null, self)
-    // }
-
-    if (!providers[self.source.type]) {
-      err = new Error(`no provider available for datasource type ${self.source.type}`, __filename)
+    if (!providers[this.source.type]) {
+      err = new Error(`no provider available for datasource type ${this.source.type}`, __filename)
       console.error(err.message)
       return callback(err)
     }
 
-    self.provider = new providers[self.source.type]()
-    self.filterEvent = null
-    self.requestParams = schema.datasource.requestParams || []
-    self.chained = schema.datasource.chained || null
+    this.provider = new providers[this.source.type]()
+    this.filterEvent = null
+    this.requestParams = schema.datasource.requestParams || []
+    this.chained = schema.datasource.chained || null
 
     if (schema.datasource.filterEvent) {
-      self.filterEvent = new Event(null, schema.datasource.filterEvent, self.options)
+      this.filterEvent = new Event(null, schema.datasource.filterEvent, this.options)
     }
 
-    self.provider.initialise(self, schema)
+    this.provider.initialise(this, schema)
 
-    callback(null, self)
+    callback(null, this)
   })
 }
 
@@ -91,13 +85,16 @@ Datasource.prototype.loadDatasource = function (done) {
 }
 
 /**
+ * Process each of the datasource's requestParams, testing for a matching
+ * parameter in the querystring (and added to req.params e.g. `/car/:make/:model`) or a matching
+ * placeholder in the datasource's endpoint (e.g. `/car/makes/{make}`)
+ *
+ * Called from lib/controller/index.js:processSearchParameters
+ *
  * @param  {string} datasource - datasource key
+ * @param  {IncomingMessage} req - the original HTTP request
  */
 Datasource.prototype.processRequest = function (datasource, req) {
-  // called from lib/controller:processSearchParameters for reason:
-  // | process each of the datasource's requestParams, testing for their existence
-  // | in the querystring's request params e.g. /car-reviews/:make/:model
-
   this.schema.datasource.filter = this.originalFilter
 
   var query = url.parse(req.url, true).query
@@ -136,11 +133,11 @@ Datasource.prototype.processRequest = function (datasource, req) {
     }
 
     // URI encode each querystring value
-    _.each(query, function (value, key) {
+    _.each(query, (value, key) => {
       if (key === 'filter') {
         _.extend(this.schema.datasource.filter, JSON.parse(value))
       }
-    }, this)
+    })
   }
 
   // Regular expression search for {param.nameOfParam} and replace with requestParameters
@@ -153,20 +150,32 @@ Datasource.prototype.processRequest = function (datasource, req) {
     }
   }))
 
-  // add the datasource's requestParams, testing for their existence
-  // in the querystring's request params e.g. /car-reviews/:make/:model
-  // NB don't replace a property that already exists
+  // Process each of the datasource's requestParams, testing for a matching
+  // parameter in the querystring (and added to req.params e.g. `/car/:make/:model`) or a matching
+  // placeholder in the datasource's endpoint (e.g. `/car/makes/{make}`)
+
+  // NB don't replace filter properties that already exist
   _.each(this.requestParams, (obj) => {
-    if (obj.field && req.params.hasOwnProperty(obj.param)) {
-      if (obj.type === 'Number') {
-        this.schema.datasource.filter[obj.field] = Number(req.params[obj.param])
-      } else {
-        this.schema.datasource.filter[obj.field] = encodeURIComponent(req.params[obj.param])
+    // if the requestParam has no 'target' property, it's destined for the filter
+    if (!obj.target) obj.target = 'filter'
+
+    var paramValue = req.params.hasOwnProperty(obj.param) && req.params[obj.param]
+
+    if (obj.field && paramValue) {
+      paramValue = obj.type === 'Number' ? Number(paramValue) : encodeURIComponent(paramValue)
+
+      if (obj.target === 'filter') {
+        this.schema.datasource.filter[obj.field] = paramValue
+      } else if (obj.target === 'endpoint') {
+        var placeholderRegex = new RegExp('{' + obj.field + '}', 'ig')
+        this.schema.datasource.source.endpoint = this.schema.datasource.source.endpoint.replace(placeholderRegex, paramValue)
       }
     } else {
-      // param not found in request, remove it from DS filter
-      if (this.schema.datasource.filter[obj.field]) {
-        delete this.schema.datasource.filter[obj.field]
+      if (obj.target === 'filter') {
+        // param not found in request, remove it from the datasource filter
+        if (this.schema.datasource.filter[obj.field]) {
+          delete this.schema.datasource.filter[obj.field]
+        }
       }
     }
   })

--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
     "standard": "8.x.x",
     "superagent": "^1.8.0-beta.2",
     "superagent-mock": "^1.10.0",
-    "supertest": "latest",
-    "semantic-release": "^6.3.2"
+    "supertest": "latest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds support for injecting request parameters into datasource endpoints.

Required: 
1. a `requestParams` block in the datasource
2. a request param including a `target` property set to `endpoint` e.g. `{ param: "channel", "field": "channelName", "target": "endpoint" }`
3. a datasource endpoint containing a placeholder which matched the above param.field e.g. `1.0/channels/{channelName}`

Close #135 