### PR TITLE
Serve host-specific static files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "init": "validate-commit-msg",
     "start": "node ./main.js",
-    "test": "standard && env NODE_ENV=test ./node_modules/.bin/istanbul cover -x '**/workspace/**' -x '**/app/**' --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha test",
+    "test": "snazzy && env NODE_ENV=test ./node_modules/.bin/istanbul cover -x '**/workspace/**' -x '**/app/**' --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha test",
     "posttest": "node ./scripts/coverage.js",
     "postinstall": "node ./scripts/copy-config.js && node ./scripts/copy-workspace.js && node ./scripts/init-web.js",
     "snyk-protect": "snyk protect",
@@ -85,6 +85,7 @@
     "proxyquire": "1.7.3",
     "should": "11.2.x",
     "sinon": "1.17.7",
+    "snazzy": "^6.0.0",
     "standard": "8.x.x",
     "superagent": "^1.8.0-beta.2",
     "superagent-mock": "^1.10.0",

--- a/test/acceptance/routing.js
+++ b/test/acceptance/routing.js
@@ -59,6 +59,8 @@ describe('Routing', function (done) {
       }
     }
 
+    TestHelper.setupApiIntercepts()
+
     TestHelper.updateConfig(configUpdate).then(() => {
       TestHelper.disableApiConfig().then(() => {
 

--- a/test/help.js
+++ b/test/help.js
@@ -189,6 +189,7 @@ TestHelper.prototype.startServer = function (pages) {
           var controller = Controller(page, options)
 
           Server.addComponent({
+            host: '',
             key: page.key,
             routes: page.routes,
             component: controller

--- a/test/unit/router.js
+++ b/test/unit/router.js
@@ -131,6 +131,7 @@ describe('Router', function (done) {
     describe('Configurable', function (done) {
       beforeEach(function (done) {
         TestHelper.resetConfig().then(() => {
+          TestHelper.setupApiIntercepts()
           done()
         })
       })
@@ -345,9 +346,16 @@ describe('Router', function (done) {
     })
 
     it('should redirect to new location if the current request URL is found in a rewrites file', function (done) {
+      TestHelper.setupApiIntercepts()
+
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ rewrites: { path: 'test/app/routes/rewrites.txt' } }).then(() => {
           var pages = TestHelper.setUpPages()
+
+          var apiConnectionString = 'http://' + config.get('api.host') + ':' + config.get('api.port')
+          var scope = nock(apiConnectionString)
+          .get('/1.0/cars/makes?count=20&page=1&filter=%7B%7D&fields=%7B%22name%22:1,%22_id%22:0%7D&sort=%7B%22name%22:1%7D')
+          .reply(200, {})
 
           TestHelper.startServer(pages).then(() => {
             var client = request(connectionString)
@@ -364,9 +372,16 @@ describe('Router', function (done) {
     })
 
     it('should return 403 status if redirect rule specifies it', function (done) {
+      TestHelper.setupApiIntercepts()
+
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ rewrites: { path: 'test/app/routes/rewrites.txt' } }).then(() => {
           var pages = TestHelper.setUpPages()
+
+          var apiConnectionString = 'http://' + config.get('api.host') + ':' + config.get('api.port')
+          var scope = nock(apiConnectionString)
+          .get('/1.0/cars/makes?count=20&page=1&filter=%7B%7D&fields=%7B%22name%22:1,%22_id%22:0%7D&sort=%7B%22name%22:1%7D')
+          .reply(200, {})
 
           TestHelper.startServer(pages).then(() => {
             var client = request(connectionString)
@@ -382,9 +397,16 @@ describe('Router', function (done) {
     })
 
     it('should return 410 status if redirect rule specifies it', function (done) {
+      TestHelper.setupApiIntercepts()
+
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ rewrites: { path: 'test/app/routes/rewrites.txt' } }).then(() => {
           var pages = TestHelper.setUpPages()
+
+          var apiConnectionString = 'http://' + config.get('api.host') + ':' + config.get('api.port')
+          var scope = nock(apiConnectionString)
+          .get('/1.0/cars/makes?count=20&page=1&filter=%7B%7D&fields=%7B%22name%22:1,%22_id%22:0%7D&sort=%7B%22name%22:1%7D')
+          .reply(200, {})
 
           TestHelper.startServer(pages).then(() => {
             var client = request(connectionString)
@@ -400,9 +422,16 @@ describe('Router', function (done) {
     })
 
     it('should return content-type if redirect rule specifies it', function (done) {
+      TestHelper.setupApiIntercepts()
+
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ rewrites: { path: 'test/app/routes/rewrites.txt' } }).then(() => {
           var pages = TestHelper.setUpPages()
+
+          var apiConnectionString = 'http://' + config.get('api.host') + ':' + config.get('api.port')
+          var scope = nock(apiConnectionString)
+          .get('/1.0/cars/makes?count=20&page=1&filter=%7B%7D&fields=%7B%22name%22:1,%22_id%22:0%7D&sort=%7B%22name%22:1%7D')
+          .reply(200, {})
 
           TestHelper.startServer(pages).then(() => {
             var client = request(connectionString)
@@ -442,6 +471,11 @@ describe('Router', function (done) {
 
           console.log(pages)
 
+          var apiConnectionString = 'http://' + config.get('api.host') + ':' + config.get('api.port')
+          var scope = nock(apiConnectionString)
+          .get('/1.0/cars/makes?count=20&page=1&filter=%7B%7D&fields=%7B%22name%22:1,%22_id%22:0%7D&sort=%7B%22name%22:1%7D')
+          .reply(200, {})
+
           TestHelper.startServer(pages).then(() => {
             var client = request(connectionString)
             client
@@ -458,6 +492,8 @@ describe('Router', function (done) {
     })
 
     it('should proxy the request if rewrite rule specifies', function (done) {
+      TestHelper.setupApiIntercepts()
+
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ rewrites: { path: 'test/app/routes/rewrites.txt' } }).then(() => {
           var pages = TestHelper.setUpPages()
@@ -489,6 +525,8 @@ describe('Router', function (done) {
           datasource: 'redirects'
         }
       }
+
+      TestHelper.setupApiIntercepts()
 
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig(routerConfig).then(() => {
@@ -531,6 +569,8 @@ describe('Router', function (done) {
           datasource: 'redirects'
         }
       }
+
+      TestHelper.setupApiIntercepts()
 
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig(configUpdate).then(() => {


### PR DESCRIPTION
Add a check before executing the serve-static method, that the current host matches one of the hosts loaded in the virtual host configuration.

Fix #144 