### PR TITLE
Use dedicated DADI API provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://dadi.tech/assets/products/dadi-web.png" alt="DADI Web" height="65"/>
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/web.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/web)
-[![coverage](https://img.shields.io/badge/coverage-73%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/web)
+[![coverage](https://img.shields.io/badge/coverage-70%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/web)
 [![Build Status](https://travis-ci.org/dadi/web.svg?branch=master)](https://travis-ci.org/dadi/web)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 

--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -32,7 +32,7 @@ Datasource.prototype.init = function (callback) {
     this.originalFilter = _.clone(this.schema.datasource.filter)
 
     if (!this.source.type) {
-      this.source.type = 'remote'
+      this.source.type = 'dadiapi'
     }
 
     if (!providers[this.source.type]) {

--- a/dadi/lib/providers/dadiapi.js
+++ b/dadi/lib/providers/dadiapi.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const _ = require('underscore')
-const debug = require('debug')('web:provider:remote')
+const debug = require('debug')('web:provider:dadi-api')
 const url = require('url')
 const http = require('http')
 const https = require('https')
@@ -14,7 +14,7 @@ const help = require(path.join(__dirname, '/../help'))
 const BearerAuthStrategy = require(path.join(__dirname, '/../auth/bearer'))
 const DatasourceCache = require(path.join(__dirname, '/../cache/datasource'))
 
-const RemoteProvider = function () {}
+const DadiApiProvider = function () {}
 
 /**
  * initialise - initialises the datasource provider
@@ -23,12 +23,11 @@ const RemoteProvider = function () {}
  * @param  {obj} schema - the schema that this provider works with
  * @return {void}
  */
-RemoteProvider.prototype.initialise = function initialise (datasource, schema) {
+DadiApiProvider.prototype.initialise = function initialise (datasource, schema) {
   this.datasource = datasource
   this.schema = schema
   this.setAuthStrategy()
   this.buildEndpoint()
-  this.redirects = 0
 }
 
 /**
@@ -36,13 +35,16 @@ RemoteProvider.prototype.initialise = function initialise (datasource, schema) {
  *
  * @return {void}
  */
-RemoteProvider.prototype.buildEndpoint = function buildEndpoint () {
+DadiApiProvider.prototype.buildEndpoint = function buildEndpoint () {
+  const apiConfig = config.get('api')
   const source = this.schema.datasource.source
 
   const protocol = source.protocol || 'http'
-  const port = source.port || 80
+  const host = source.host || apiConfig.host
+  const port = source.port || apiConfig.port
 
-  const uri = [protocol, '://', source.host, (port !== '' ? ':' + port : ''), '/', this.datasource.source.modifiedEndpoint || source.endpoint].join('')
+  const uri = [protocol, '://', host, (port !== '' ? ':' : ''),
+    port, '/', this.datasource.source.modifiedEndpoint || source.endpoint].join('')
 
   this.endpoint = this.processDatasourceParameters(this.schema, uri)
 }
@@ -53,7 +55,7 @@ RemoteProvider.prototype.buildEndpoint = function buildEndpoint () {
  * @param  {fn} done - callback
  * @return {void}
  */
-RemoteProvider.prototype.getHeaders = function getHeaders (done) {
+DadiApiProvider.prototype.getHeaders = function getHeaders (done) {
   const headers = {
     'accept-encoding': 'gzip'
   }
@@ -74,7 +76,30 @@ RemoteProvider.prototype.getHeaders = function getHeaders (done) {
       })
     }
   } else {
-    return done(null, { headers: headers })
+    try {
+      help.getToken(this.datasource).then((bearerToken) => {
+        headers['Authorization'] = 'Bearer ' + bearerToken
+
+        help.timer.stop('auth')
+        return done(null, { headers: headers })
+      }).catch((errorData) => {
+        const err = new Error()
+        err.name = errorData.title
+        err.message = errorData.detail
+        err.remoteIp = config.get('api.host')
+        err.remotePort = config.get('api.port')
+        err.path = config.get('auth.tokenUrl')
+
+        if (errorData.stack) {
+          console.log(errorData.stack)
+        }
+
+        help.timer.stop('auth')
+        return done(err)
+      })
+    } catch (err) {
+      console.log(err.stack)
+    }
   }
 }
 
@@ -85,7 +110,7 @@ RemoteProvider.prototype.getHeaders = function getHeaders (done) {
  * @param  {fn} done - callback
  * @return {void}
  */
-RemoteProvider.prototype.handleResponse = function handleResponse (res, done) {
+DadiApiProvider.prototype.handleResponse = function handleResponse (res, done) {
   const encoding = res.headers['content-encoding'] ? res.headers['content-encoding'] : ''
   let output = ''
 
@@ -126,8 +151,8 @@ RemoteProvider.prototype.handleResponse = function handleResponse (res, done) {
  * @param  {string} protocol
  * @return {module} http|https
  */
-RemoteProvider.prototype.keepAliveAgent = function keepAliveAgent (protocol) {
-  return (protocol.indexOf('https') > -1)
+DadiApiProvider.prototype.keepAliveAgent = function keepAliveAgent (protocol) {
+  return (protocol === 'https')
     ? new https.Agent({ keepAlive: true })
     : new http.Agent({ keepAlive: true })
 }
@@ -139,18 +164,19 @@ RemoteProvider.prototype.keepAliveAgent = function keepAliveAgent (protocol) {
  * @param  {fn} done - callback on error or completion
  * @return {void}
  */
-RemoteProvider.prototype.load = function (requestUrl, done) {
+DadiApiProvider.prototype.load = function (requestUrl, done) {
   this.requestUrl = requestUrl
   this.dataCache = DatasourceCache()
 
   this.options = {
-    protocol: this.datasource.source.protocol,
-    host: this.datasource.source.host,
-    port: this.datasource.source.port || 80,
+    protocol: this.datasource.source.protocol || config.get('api.protocol'),
+    host: this.datasource.source.host || config.get('api.host'),
+    port: this.datasource.source.port || config.get('api.port'),
     path: url.parse(this.endpoint).path,
     method: 'GET'
   }
 
+  this.options.agent = this.keepAliveAgent(this.options.protocol)
   this.options.protocol = this.options.protocol + ':'
 
   this.dataCache.getFromCache(this.datasource, (cachedData) => {
@@ -159,53 +185,29 @@ RemoteProvider.prototype.load = function (requestUrl, done) {
     debug('load %s', this.endpoint)
 
     this.getHeaders((err, headers) => {
-      if (err) return done(err)
+      err && done(err)
 
       this.options = _.extend(this.options, headers)
 
-      this.makeRequest(done)
-    })
-  })
-}
+      log.info({module: 'helper'}, "GET datasource '" + this.datasource.schema.datasource.key + "': " + this.options.path)
 
-RemoteProvider.prototype.makeRequest = function (done) {
-  debug('GET datasource "%s" %o', this.datasource.schema.datasource.key, _.omit(this.options, 'agent'))
+      const agent = (this.options.protocol === 'https') ? https : http
+      let request = agent.request(this.options, (res) => {
+        this.handleResponse(res, done)
+      })
 
-  this.options.agent = this.keepAliveAgent(this.options.protocol)
-
-  const agent = (this.options.protocol.indexOf('https') > -1) ? https : http
-
-  let request = agent.request(this.options, (res) => {
-    if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307) {
-      this.redirects++
-
-      if (this.redirects >= 10) {
-        var err = new Error('Infinite redirect loop detected')
+      request.on('error', (err) => {
+        const message = err.toString() + ". Couldn't request data from " + this.datasource.endpoint
+        err.name = 'GetData'
+        err.message = message
         err.remoteIp = this.options.host
         err.remotePort = this.options.port
         return done(err)
-      }
+      })
 
-      var options = url.parse(res.headers.location)
-      this.options = _.extend(this.options, options)
-
-      debug('following %s redirect to %s', res.statusCode, res.headers.location)
-      this.makeRequest(done)
-    } else {
-      this.handleResponse(res, done)
-    }
+      request.end()
+    })
   })
-
-  request.on('error', (err) => {
-    const message = err.toString() + ". Couldn't request data from " + this.datasource.endpoint
-    err.name = 'GetData'
-    err.message = message
-    err.remoteIp = this.options.host
-    err.remotePort = this.options.port
-    return done(err)
-  })
-
-  request.end()
 }
 
 /**
@@ -213,10 +215,36 @@ RemoteProvider.prototype.makeRequest = function (done) {
  *
  * @param  {Object} schema - the datasource schema
  * @param  {type} uri - the original datasource endpoint
- * @returns {string} the original uri
+ * @returns {string} uri with query string appended
  */
-RemoteProvider.prototype.processDatasourceParameters = function processDatasourceParameters (schema, uri) {
-  return uri
+DadiApiProvider.prototype.processDatasourceParameters = function processDatasourceParameters (schema, uri) {
+  debug('processDatasourceParameters %s', uri)
+  let query = '?'
+
+  const params = [
+    { 'count': (schema.datasource.count || 0) },
+    { 'skip': (schema.datasource.skip) },
+    { 'page': (schema.datasource.page || 1) },
+    { 'referer': schema.datasource.referer },
+    { 'filter': schema.datasource.filter || {} },
+    { 'fields': schema.datasource.fields || {} },
+    { 'sort': this.processSortParameter(schema.datasource.sort) }
+  ]
+
+  // pass cache flag to API endpoint
+  if (schema.datasource.hasOwnProperty('cache')) {
+    params.push({ 'cache': schema.datasource.cache })
+  }
+
+  params.forEach((param) => {
+    for (let key in param) {
+      if (param.hasOwnProperty(key) && (typeof param[key] !== 'undefined')) {
+        query = query + key + '=' + (_.isObject(param[key]) ? JSON.stringify(param[key]) : param[key]) + '&'
+      }
+    }
+  })
+
+  return uri + query.slice(0, -1)
 }
 
 /**
@@ -227,7 +255,7 @@ RemoteProvider.prototype.processDatasourceParameters = function processDatasourc
  * @param  {fn} done
  * @return {void}
  */
-RemoteProvider.prototype.processOutput = function processOutput (res, data, done) {
+DadiApiProvider.prototype.processOutput = function processOutput (res, data, done) {
   // Return a 202 Accepted response immediately,
   // along with the datasource response
   if (res.statusCode === 202) {
@@ -284,8 +312,34 @@ RemoteProvider.prototype.processOutput = function processOutput (res, data, done
  * @param  {obj} req - web request object
  * @return {void}
  */
-RemoteProvider.prototype.processRequest = function processRequest (req) {
+DadiApiProvider.prototype.processRequest = function processRequest (req) {
   this.buildEndpoint()
+}
+
+/**
+ * processSortParameter
+ *
+ * @param  {?} obj - sort parameter
+ * @return {?}
+ */
+DadiApiProvider.prototype.processSortParameter = function processSortParameter (obj) {
+  let sort = {}
+
+  if (typeof obj !== 'object' || obj === null) return sort
+
+  if (_.isArray(obj)) {
+    _.each(obj, (value, key) => {
+      if (typeof value === 'object' && value.hasOwnProperty('field') && value.hasOwnProperty('order')) {
+        sort[value.field] = (value.order === 'asc') ? 1 : -1
+      }
+    })
+  } else if (obj.hasOwnProperty('field') && obj.hasOwnProperty('order')) {
+    sort[obj.field] = (obj.order === 'asc') ? 1 : -1
+  } else {
+    sort = obj
+  }
+
+  return sort
 }
 
 /**
@@ -293,9 +347,9 @@ RemoteProvider.prototype.processRequest = function processRequest (req) {
  *
  * @return {void}
  */
-RemoteProvider.prototype.setAuthStrategy = function setAuthStrategy () {
+DadiApiProvider.prototype.setAuthStrategy = function setAuthStrategy () {
   if (!this.schema.datasource.auth) return null
   this.authStrategy = new BearerAuthStrategy(this.schema.datasource.auth)
 }
 
-module.exports = RemoteProvider
+module.exports = DadiApiProvider

--- a/dadi/lib/providers/remote.js
+++ b/dadi/lib/providers/remote.js
@@ -8,9 +8,7 @@ const https = require('https')
 const path = require('path')
 const zlib = require('zlib')
 
-const config = require(path.join(__dirname, '/../../../config.js'))
 const log = require('@dadi/logger')
-const help = require(path.join(__dirname, '/../help'))
 const BearerAuthStrategy = require(path.join(__dirname, '/../auth/bearer'))
 const DatasourceCache = require(path.join(__dirname, '/../cache/datasource'))
 

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -12,6 +12,7 @@ var TestHelper = require(__dirname + '/../help')()
 var config = require(__dirname + '/../../config')
 var help = require(__dirname + '/../../dadi/lib/help')
 var remoteProvider = require(__dirname + '/../../dadi/lib/providers/remote')
+var apiProvider = require(__dirname + '/../../dadi/lib/providers/dadiapi')
 
 var connectionString = 'http://' + config.get('server.host') + ':' + config.get('server.port')
 
@@ -264,7 +265,7 @@ describe('Controller', function (done) {
           .get(/cars\/makes/)
           .reply(200, results2)
 
-        var providerSpy = sinon.spy(remoteProvider.prototype, 'load')
+        var providerSpy = sinon.spy(apiProvider.prototype, 'load')
 
         TestHelper.startServer(pages).then(() => {
           var client = request(connectionString)
@@ -318,7 +319,7 @@ describe('Controller', function (done) {
           .get(endpoint2)
           .reply(200, results2)
 
-        var providerSpy = sinon.spy(remoteProvider.prototype, 'load')
+        var providerSpy = sinon.spy(apiProvider.prototype, 'load')
 
         TestHelper.startServer(pages).then(() => {
           var client = request(connectionString)

--- a/test/unit/data-providers.js
+++ b/test/unit/data-providers.js
@@ -14,6 +14,7 @@ var Controller = require(__dirname + '/../../dadi/lib/controller')
 var Datasource = require(__dirname + '/../../dadi/lib/datasource')
 var help = require(__dirname + '/../../dadi/lib/help')
 var Page = require(__dirname + '/../../dadi/lib/page')
+var apiProvider = require(__dirname + '/../../dadi/lib/providers/dadiapi')
 var remoteProvider = require(__dirname + '/../../dadi/lib/providers/remote')
 var Server = require(__dirname + '/../../dadi/lib')
 var TestHelper = require(__dirname + '/../help')()
@@ -39,7 +40,7 @@ describe('Data Providers', function (done) {
     done()
   })
 
-  describe('Remote', function (done) {
+  describe('DADI API', function (done) {
     it('should use the datasource auth block when obtaining a token', function (done) {
       TestHelper.enableApiConfig().then(() => {
         TestHelper.updateConfig({'allowJsonView': true}).then(() => {
@@ -93,7 +94,7 @@ describe('Data Providers', function (done) {
           .times(5)
           .reply(200, data)
 
-          var providerSpy = sinon.spy(remoteProvider.prototype, 'processOutput')
+          var providerSpy = sinon.spy(apiProvider.prototype, 'processOutput')
 
           TestHelper.startServer(pages).then(() => {
             var client = request(connectionString)

--- a/test/unit/preloader.js
+++ b/test/unit/preloader.js
@@ -11,7 +11,7 @@ var Controller = require(__dirname + '/../../dadi/lib/controller')
 var datasource = require(__dirname + '/../../dadi/lib/datasource');
 var Page = require(__dirname + '/../../dadi/lib/page')
 var Preload = require(path.resolve(path.join(__dirname, '/../../dadi/lib/datasource/preload')))
-var remoteProvider = require(__dirname + '/../../dadi/lib/providers/remote')
+var apiProvider = require(__dirname + '/../../dadi/lib/providers/dadiapi')
 var TestHelper = require(__dirname + '/../help')()
 
 var config = require(path.resolve(path.join(__dirname, '/../../config')))
@@ -39,13 +39,13 @@ describe('Preloader', function (done) {
 
         // provide API response
         var results = { results: [{ "make": "ford" }, { "make": "mazda" }, { "make": "toyota" }] }
-        var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+        var providerStub = sinon.stub(apiProvider.prototype, 'load')
         providerStub.onFirstCall().yields(null, results)
 
         var preloadSpy = sinon.spy(Preload.Preload.prototype, 'init')
 
         TestHelper.startServer(pages).then(() => {
-          remoteProvider.prototype.load.restore()
+          apiProvider.prototype.load.restore()
           preloadSpy.restore()
 
           preloadSpy.called.should.eql(true)

--- a/test/unit/router.js
+++ b/test/unit/router.js
@@ -11,7 +11,7 @@ var Controller = require(__dirname + '/../../dadi/lib/controller')
 var datasource = require(__dirname + '/../../dadi/lib/datasource')
 var libHelp = require(__dirname + '/../../dadi/lib/help')
 var Page = require(__dirname + '/../../dadi/lib/page')
-var remoteProvider = require(__dirname + '/../../dadi/lib/providers/remote')
+var apiProvider = require(__dirname + '/../../dadi/lib/providers/dadiapi')
 var Router = require(__dirname + '/../../dadi/lib/controller/router')
 var Server = require(__dirname + '/../../dadi/lib')
 var TestHelper = require(__dirname + '/../help')()
@@ -150,7 +150,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{'make': 'ford'}] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -185,7 +185,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{'make': 'ford'}] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -220,7 +220,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{'make': 'ford'}] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -255,7 +255,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{'make': 'ford'}] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -289,7 +289,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{'make': 'ford'}] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -324,7 +324,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{'make': 'ford'}] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -535,7 +535,7 @@ describe('Router', function (done) {
 
           // provide API response
           var redirectResults = { results: [{'rule': '/test', 'replacement': '/books', 'redirectType': 301}] }
-          var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+          var providerStub = sinon.stub(apiProvider.prototype, 'load')
           providerStub.yields(null, redirectResults)
 
           TestHelper.startServer(pages).then(() => {
@@ -579,7 +579,7 @@ describe('Router', function (done) {
 
           // provide API response
           var redirectResults = { results: [{'rule': '/test', 'replacement': '/books', 'redirectType': 301}] }
-          var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+          var providerStub = sinon.stub(apiProvider.prototype, 'load')
           providerStub.yields(null, redirectResults)
 
           TestHelper.startServer(pages).then(() => {
@@ -742,7 +742,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{ "make": "ford" }, { "make": "mazda" }, { "make": "toyota" }] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.onFirstCall().yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -767,7 +767,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{ "make": "ford" }, { "make": "mazda" }, { "make": "toyota" }] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.onFirstCall().yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -809,7 +809,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [{ "name": "ford" }, { "name": "mazda" }, { "name": "toyota" }] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.onFirstCall().yields(null, results)
 
             TestHelper.startServer(pages).then(() => {
@@ -834,7 +834,7 @@ describe('Router', function (done) {
 
             // provide API response
             var results = { results: [] }
-            var providerStub = sinon.stub(remoteProvider.prototype, 'load')
+            var providerStub = sinon.stub(apiProvider.prototype, 'load')
             providerStub.onFirstCall().yields(null, results)
 
             TestHelper.startServer(pages).then(() => {


### PR DESCRIPTION
Defaults all datasources to `"type": "dadiapi"`

Creates new provider `remote` for misc API calling:

```
{
  "datasource": {
    "key": "instagram",
    "name": "Grab instagram posts for a specific user",
    "source": {
      "type": "remote",
      "protocol": "http",
      "host": "instagram.com",
      "endpoint": "{user}/?__a=1"
    },
    "auth": false,
    "requestParams": [
      {
        "param": "user",
        "field": "user",
        "target": "endpoint"
      }
    ]
  }
}
```

Close #142 
Close #143  
