### PR TITLE
Provider rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.11.2] - 2017-06-19
+
+## Changed
+* modify the controller to make it initialise each datasource's data provider just before it is used, then destroy it after the data is returned
+
 # [1.11.0] - 2017-06-11
 
 ## Added

--- a/dadi/lib/auth/index.js
+++ b/dadi/lib/auth/index.js
@@ -10,7 +10,7 @@ var log = require('@dadi/logger')
 // This attaches middleware to the passed in app instance
 module.exports = function (server) {
   server.app.use(function (req, res, next) {
-    log.info({module: 'auth'}, 'Retrieving access token for "' + req.url + '"')
+    log.debug({module: 'auth'}, 'Retrieving access token for "' + req.url + '"')
     help.timer.start('auth')
 
     return help.getToken().then(function (bearerToken) {

--- a/dadi/lib/cache/datasource.js
+++ b/dadi/lib/cache/datasource.js
@@ -7,16 +7,19 @@ var merge = require('deepmerge')
 var path = require('path')
 var url = require('url')
 
-var Cache = require(path.join(__dirname, '/index.js'))
+// var Cache = require(path.join(__dirname, '/index.js'))
+var DadiCache = require('@dadi/cache')
 var config = require(path.join(__dirname, '/../../../config.js'))
+var log = require('@dadi/logger')
 
 /**
  * Creates a new DatasourceCache singleton for caching datasource results
  * @constructor
  */
 var DatasourceCache = function () {
-  this.cache = Cache().cache
+  //  this.cache = Cache().cache
   this.cacheOptions = config.get('caching')
+  this.cache = new DadiCache(this.cacheOptions)
 
   DatasourceCache.numInstances = (DatasourceCache.numInstances || 0) + 1
   // console.log('DatasourceCache:', DatasourceCache.numInstances)
@@ -28,31 +31,111 @@ var DatasourceCache = function () {
 }
 
 /**
+ * Get datasource data from the cache if it exists
+ * @param {object} datasource - a datasource schema object containing the datasource settings
+ * @param {fn} done - the method to call when finished, accepts 1 arg:
+ *   if the cache key was found, returns {Buffer} data
+ *   if the cache key was not found, returns false
+ */
+DatasourceCache.prototype.getFromCache = function (opts, done) {
+  debug('get (%s)', opts.name)
+
+  if (!this.cachingEnabled(opts)) {
+    return done(false)
+  }
+
+  if (this.stillCaching) {
+    return done(false)
+  }
+
+  var filename = this.getFilename(opts)
+  var options = this.getOptions(opts)
+
+  var buffers = []
+
+  // attempt to get from the cache
+  this.cache.get(filename, options).then((stream) => {
+    debug('serving %s from cache (%s)', opts.name, filename)
+    log.info('serving %s from cache (%s)', opts.name, filename)
+
+    stream.on('data', (chunk) => {
+      if (chunk) {
+        buffers.push(chunk)
+      }
+    })
+
+    stream.on('end', () => {
+      return done(Buffer.concat(buffers))
+    })
+  }).catch(() => {
+    // key doesn't exist in cache
+    return done(false)
+  })
+}
+
+/**
+ * Cache the supplied data it caching is enabled for the datasource
+ *
+ * @param  {Object} datasource - the datasource instance
+ * @param  {Buffer} data - the body of the response as a Buffer
+ * @param  {fn} done - the method to call when finished, accepts args (Boolean written)
+ */
+DatasourceCache.prototype.cacheResponse = function (opts, data, done) {
+  var enabled = this.cachingEnabled(opts)
+
+  if (!enabled) {
+    return done(false)
+  }
+
+  if (this.stillCaching) {
+    // console.log('stillCaching...')
+    return done(false)
+  }
+
+  debug('write to cache (%s)', opts.name)
+
+  var filename = this.getFilename(opts)
+  var options = this.getOptions(opts)
+
+  // console.log('> CACHE RESPONSE')
+  // console.log('is Buffer?', Buffer.isBuffer(data))
+  // console.log(filename, opts.endpoint)
+
+  this.stillCaching = true
+
+  this.cache.set(filename, data, options).then(() => {
+    // console.log('< CACHE RESPONSE', filename)
+    this.stillCaching = false
+    return done(true)
+  })
+}
+
+/**
  *
  * @param {object} datasource - a datasource schema object containing the datasource settings
  */
-DatasourceCache.prototype.cachingEnabled = function (datasource) {
+DatasourceCache.prototype.cachingEnabled = function (opts) {
   var enabled = this.enabled
 
   // check the querystring for a no cache param
-  if (typeof datasource.provider.endpoint !== 'undefined') {
-    var query = url.parse(datasource.provider.endpoint, true).query
+  if (typeof opts.endpoint !== 'undefined') {
+    var query = url.parse(opts.endpoint, true).query
     if (query.cache && query.cache === 'false') {
       enabled = false
     }
   }
 
-  if (datasource.source.type === 'static') {
-    enabled = false
-  }
+  // if (datasource.source.type === 'static') {
+  //   enabled = false
+  // }
 
   if (config.get('debug')) {
     enabled = false
   }
 
-  var options = this.getOptions(datasource)
+  var options = this.getOptions(opts)
 
-  debug('options (%s): %o', datasource.name, options)
+  debug('options (%s): %o', opts.name, options)
 
   // enabled if the datasource caching block says it's enabled
   return enabled && (options.directory.enabled || options.redis.enabled)
@@ -66,13 +149,13 @@ DatasourceCache.prototype.cachingEnabled = function (datasource) {
  * a unique cacheKey instead
  * @param {object} datasource - a datasource schema object containing the datasource settings
  */
-DatasourceCache.prototype.getFilename = function (datasource) {
-  var filename = crypto.createHash('sha1').update(datasource.name).digest('hex')
+DatasourceCache.prototype.getFilename = function (opts) {
+  var filename = crypto.createHash('sha1').update(opts.name).digest('hex')
 
-  if (datasource.provider.cacheKey) {
-    filename += '_' + crypto.createHash('sha1').update(datasource.provider.cacheKey).digest('hex')
+  if (opts.cacheKey) {
+    filename += '_' + crypto.createHash('sha1').update(opts.cacheKey).digest('hex')
   } else {
-    filename += '_' + crypto.createHash('sha1').update(datasource.provider.endpoint).digest('hex')
+    filename += '_' + crypto.createHash('sha1').update(opts.endpoint).digest('hex')
   }
 
   return filename
@@ -83,73 +166,16 @@ DatasourceCache.prototype.getFilename = function (datasource) {
  * @param {object} datasource - a datasource schema object containing the datasource settings
  * @returns {object} options for the cache
  */
-DatasourceCache.prototype.getOptions = function (datasource) {
-  var options = merge(this.cacheOptions, datasource.schema.datasource.caching || {})
+DatasourceCache.prototype.getOptions = function (opts) {
+  var options = merge(this.cacheOptions, opts.caching || {})
 
   options.directory.extension = 'json'
 
   return options
 }
 
-/**
- *
- * @param {object} datasource - a datasource schema object containing the datasource settings
- */
-DatasourceCache.prototype.getFromCache = function (datasource, done) {
-  debug('get (%s)', datasource.name)
-
-  if (!this.cachingEnabled(datasource)) {
-    return done(false)
-  }
-
-  var filename = this.getFilename(datasource)
-  var options = this.getOptions(datasource)
-
-  var data = ''
-
-  // attempt to get from the cache
-  this.cache.get(filename, options).then((stream) => {
-    debug('serving %s from cache (%s)', datasource.name, filename)
-
-    stream.on('data', (chunk) => {
-      if (chunk) data += chunk
-    })
-
-    stream.on('end', () => {
-      return done(data)
-    })
-  }).catch(() => {
-    // key doesn't exist in cache
-    return done(false)
-  })
-}
-
-/**
- *
- */
-DatasourceCache.prototype.cacheResponse = function (datasource, data, done) {
-  var enabled = this.cachingEnabled(datasource)
-
-  if (!enabled) {
-    return done(false)
-  }
-
-  debug('write to cache (%s)', datasource.name)
-
-  var filename = this.getFilename(datasource)
-  var options = this.getOptions(datasource)
-
-  this.cache.set(filename, data, options).then(() => {
-    return done(true)
-  })
-}
+module.exports._reset = function () {}
 
 module.exports = function () {
   return new DatasourceCache()
 }
-
-module.exports._reset = function () {
-
-}
-
-module.exports.DatasourceCache = DatasourceCache

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -334,14 +334,16 @@ Controller.prototype.loadData = function (req, res, data, done) {
         ds.provider = new Providers[ds.source.type]()
         ds.provider.initialise(ds, ds.schema)
 
-        var requestUrl = processSearchParameters(ds.schema.datasource.key, ds, req)
+        // var requestUrl = processSearchParameters(ds.schema.datasource.key, ds, req)
+        processSearchParameters(ds.schema.datasource.key, ds, req)
 
         /**
          * Call the data provider's load method to obtain data
          * for this datasource
          * @returns err, {Object} result, {Object} dsResponse
          */
-        ds.provider.load(requestUrl, function (err, result, dsResponse) {
+        // ds.provider.load(requestUrl, function (err, result, dsResponse) {
+        ds.provider.load(req.url, function (err, result, dsResponse) {
           help.timer.stop('datasource: ' + ds.name)
 
           if (ds.provider.destroy) {
@@ -478,11 +480,14 @@ Controller.prototype.processChained = function (chainedDatasources, data, req, d
     chainedDatasource.provider = new Providers[chainedDatasource.source.type]()
     chainedDatasource.provider.initialise(chainedDatasource, chainedDatasource.schema)
 
-    var requestUrl = chainedDatasource.provider.buildEndpoint(chainedDatasource.schema.datasource)
+    // var requestUrl = chainedDatasource.provider.buildEndpoint(chainedDatasource.schema.datasource)
+    chainedDatasource.provider.buildEndpoint(chainedDatasource.schema.datasource)
 
-    debug('datasource (load): %s %s', chainedDatasource.name, requestUrl)
+    // debug('datasource (load): %s %s', chainedDatasource.name, requestUrl)
+    debug('datasource (load): %s %s', chainedDatasource.name, chainedDatasource.provider.endpoint)
 
-    chainedDatasource.provider.load(requestUrl, (err, chainedData) => {
+    // chainedDatasource.provider.load(requestUrl, (err, chainedData) => {
+    chainedDatasource.provider.load(req.url, (err, chainedData) => {
       if (err) log.error({module: 'controller'}, err)
 
       help.timer.stop('datasource: ' + chainedDatasource.name + ' (chained)')
@@ -508,7 +513,8 @@ Controller.prototype.processChained = function (chainedDatasources, data, req, d
 function processSearchParameters (key, datasource, req) {
   // process each of the datasource's requestParams, testing for their existence
   // in the querystring's request params e.g. /car-reviews/:make/:model
-  return datasource.processRequest(key, req)
+  // return datasource.processRequest(key, req)
+  datasource.processRequest(key, req)
 }
 
 module.exports = function (page, options, meta) {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -14,6 +14,7 @@ var log = require('@dadi/logger')
 
 var Datasource = require(path.join(__dirname, '/../datasource'))
 var Event = require(path.join(__dirname, '/../event'))
+var Providers = require(path.join(__dirname, '/../providers'))
 var View = require(path.join(__dirname, '/../view'))
 
 // helpers
@@ -293,9 +294,9 @@ Controller.prototype.loadData = function (req, res, data, done) {
 
   _.each(self.datasources, function (ds, key) {
     if (ds.chained) {
-      chainedDatasources[key] = ds
+      chainedDatasources[key] = _.clone(ds)
     } else {
-      primaryDatasources[key] = ds
+      primaryDatasources[key] = _.clone(ds)
     }
   })
 
@@ -328,23 +329,37 @@ Controller.prototype.loadData = function (req, res, data, done) {
           })
         }
 
-        processSearchParameters(ds.schema.datasource.key, ds, req)
-
         help.timer.start('datasource: ' + ds.name)
 
-        ds.provider.load(req.url, function (err, result, dsResponse) {
-          help.timer.stop('datasource: ' + ds.name)
-          if (err) return done(err)
+        ds.provider = new Providers[ds.source.type]()
+        ds.provider.initialise(ds, ds.schema)
 
-          if (dsResponse) {
-            return done(null, result, dsResponse)
+        var requestUrl = processSearchParameters(ds.schema.datasource.key, ds, req)
+
+        /**
+         * Call the data provider's load method to obtain data
+         * for this datasource
+         * @returns err, {Object} result, {Object} dsResponse
+         */
+        ds.provider.load(requestUrl, function (err, result, dsResponse) {
+          help.timer.stop('datasource: ' + ds.name)
+
+          if (ds.provider.destroy) {
+            ds.provider.destroy()
           }
 
+          ds.provider = null
+
+          if (err) return done(err)
+
+          if (dsResponse) return done(null, result, dsResponse)
+
+          // TODO: simplify this, doesn't require a try/catch
           if (result) {
             try {
-              data[ds.schema.datasource.key] = (typeof result === 'object' ? result : JSON.parse(result))
+              data[ds.schema.datasource.key] = result
             } catch (e) {
-              console.log('Provider Load Error:', ds.name, ds.provider.endpoint)
+              console.log('Provider Load Error:', ds.name, requestUrl)
               console.log(e)
             }
           }
@@ -460,17 +475,22 @@ Controller.prototype.processChained = function (chainedDatasources, data, req, d
       chainedDatasource.schema.datasource.filter = JSON.parse(filter)
     }
 
-    chainedDatasource.provider.buildEndpoint(chainedDatasource.schema, function () {})
+    chainedDatasource.provider = new Providers[chainedDatasource.source.type]()
+    chainedDatasource.provider.initialise(chainedDatasource, chainedDatasource.schema)
 
-    debug('datasource (load): %s %o', chainedDatasource.name, chainedDatasource.schema.datasource.filter)
-    chainedDatasource.provider.load(req.url, function (err, result) {
+    var requestUrl = chainedDatasource.provider.buildEndpoint(chainedDatasource.schema.datasource)
+
+    debug('datasource (load): %s %s', chainedDatasource.name, requestUrl)
+
+    chainedDatasource.provider.load(requestUrl, (err, chainedData) => {
       if (err) log.error({module: 'controller'}, err)
 
       help.timer.stop('datasource: ' + chainedDatasource.name + ' (chained)')
 
-      if (result) {
+      // TODO: simplify this, doesn't require a try/catch
+      if (chainedData) {
         try {
-          data[chainedKey] = (typeof result === 'object' ? result : JSON.parse(result))
+          data[chainedKey] = chainedData
         } catch (e) {
           log.error({module: 'controller'}, e)
         }
@@ -488,7 +508,7 @@ Controller.prototype.processChained = function (chainedDatasources, data, req, d
 function processSearchParameters (key, datasource, req) {
   // process each of the datasource's requestParams, testing for their existence
   // in the querystring's request params e.g. /car-reviews/:make/:model
-  datasource.processRequest(key, req)
+  return datasource.processRequest(key, req)
 }
 
 module.exports = function (page, options, meta) {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -361,7 +361,7 @@ Controller.prototype.loadData = function (req, res, data, done) {
             try {
               data[ds.schema.datasource.key] = result
             } catch (e) {
-              console.log('Provider Load Error:', ds.name, requestUrl)
+              console.log('Provider Load Error:', ds.name, req.url)
               console.log(e)
             }
           }

--- a/dadi/lib/controller/router.js
+++ b/dadi/lib/controller/router.js
@@ -80,7 +80,6 @@ Router.prototype.loadRewrites = function (options, done) {
         // Get redirects from API collection
         var freshRules = []
         ds.provider.load(null, function (err, response) {
-
           if (err) {
             console.log('Error loading data in Router Rewrite module')
             console.log(err)

--- a/dadi/lib/controller/router.js
+++ b/dadi/lib/controller/router.js
@@ -80,6 +80,7 @@ Router.prototype.loadRewrites = function (options, done) {
         // Get redirects from API collection
         var freshRules = []
         ds.provider.load(null, function (err, response) {
+
           if (err) {
             console.log('Error loading data in Router Rewrite module')
             console.log(err)
@@ -335,14 +336,14 @@ module.exports = function (server, options) {
 
         ds.provider.processRequest(ds.page.name, req)
 
-        ds.provider.load(req.url, function (err, result) {
+        ds.provider.load(req.url, function (err, data) {
           if (err) {
             console.log('Error loading data in Router Rewrite module')
             return next(err)
           }
 
-          if (result) {
-            var results = (typeof result === 'object') ? result : JSON.parse(result)
+          if (data) {
+            var results = JSON.parse(data.toString())
 
             if (results && results.results && results.results.length > 0 && results.results[0].rule === req.url) {
               var rule = results.results[0]

--- a/dadi/lib/controller/router.js
+++ b/dadi/lib/controller/router.js
@@ -87,12 +87,11 @@ Router.prototype.loadRewrites = function (options, done) {
             return cb(null)
           }
 
-          if (response) {
-            response = JSON.parse(response)
-          }
+          // if (response) {
+          //   response = JSON.parse(response)
+          // }
 
           if (response.results) {
-            // api.in(self.rewritesDatasource).find().then(function (response)
             var idx = 0
 
             _.each(response.results, function (rule) {
@@ -343,7 +342,8 @@ module.exports = function (server, options) {
           }
 
           if (data) {
-            var results = JSON.parse(data.toString())
+            // var results = JSON.parse(data.toString())
+            var results = data
 
             if (results && results.results && results.results.length > 0 && results.results[0].rule === req.url) {
               var rule = results.results[0]

--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -106,8 +106,6 @@ Datasource.prototype.processRequest = function (datasource, req) {
   var datasourceParams = _.clone(this.schema.datasource)
   datasourceParams.filter = this.originalFilter || {}
 
-  //console.log(datasourceParams)
-
   var query = JSON.parse(JSON.stringify(url.parse(req.url, true).query))
 
   // handle the cache flag
@@ -126,6 +124,7 @@ Datasource.prototype.processRequest = function (datasource, req) {
   if (this.page.passHeaders) {
     this.requestHeaders = req.headers
   }
+
 
   // if the current datasource matches the page name
   // add some params from the query string or request params
@@ -225,9 +224,11 @@ Datasource.prototype.processRequest = function (datasource, req) {
 
   if (typeof this.provider.processRequest === 'function') {
     if (this.provider.hasOwnProperty('processSchemaParams') && this.provider.processSchemaParams === false) {
-      return this.provider.processRequest(req)
+      // return this.provider.processRequest(req)
+      this.provider.processRequest(req)
     } else {
-      return this.provider.processRequest(datasourceParams)
+      // return this.provider.processRequest(datasourceParams)
+      this.provider.processRequest(datasourceParams)
     }
   }
 }

--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -98,9 +98,9 @@ Datasource.prototype.loadDatasource = function (done) {
  * @param  {IncomingMessage} req - the original HTTP request
  */
 Datasource.prototype.processRequest = function (datasource, req) {
-  //console.log('> DS PROCESS REQUEST')
-  //console.log(this.schema.datasource.filter)
-  //this.schema.datasource.filter = this.originalFilter
+  // console.log('> DS PROCESS REQUEST')
+  // console.log(this.schema.datasource.filter)
+  // this.schema.datasource.filter = this.originalFilter
   // var filter = this.originalFilter || {}
 
   var datasourceParams = _.clone(this.schema.datasource)
@@ -124,7 +124,6 @@ Datasource.prototype.processRequest = function (datasource, req) {
   if (this.page.passHeaders) {
     this.requestHeaders = req.headers
   }
-
 
   // if the current datasource matches the page name
   // add some params from the query string or request params
@@ -158,7 +157,7 @@ Datasource.prototype.processRequest = function (datasource, req) {
     // URI encode each querystring value
     _.each(query, (value, key) => {
       if (key === 'filter') {
-        //_.extend(this.schema.datasource.filter, JSON.parse(value))
+        // _.extend(this.schema.datasource.filter, JSON.parse(value))
         datasourceParams.filter = _.extend(datasourceParams.filter, JSON.parse(value))
       }
     })

--- a/dadi/lib/datasource/preload.js
+++ b/dadi/lib/datasource/preload.js
@@ -19,15 +19,20 @@ Preload.prototype.init = function (options) {
         return
       }
 
-      var requestUrl = datasource.processRequest('preload', req)
-
       datasource.provider = new Providers[datasource.source.type]()
       datasource.provider.initialise(datasource, datasource.schema)
 
-      datasource.provider.load(requestUrl, (err, data) => {
+      // var requestUrl = datasource.processRequest('preload', req)
+      // datasource.processRequest('preload', null)
+
+      // datasource.provider.load(requestUrl, (err, data) => {
+      datasource.provider.load(null, (err, data) => {
         if (err) console.log(err)
 
-        datasource.provider.destroy()
+        if (datasource.provider.destroy) {
+          datasource.provider.destroy()
+        }
+
         datasource.provider = null
 
         // TODO: simplify this, doesn't require a try/catch

--- a/dadi/lib/datasource/preload.js
+++ b/dadi/lib/datasource/preload.js
@@ -41,7 +41,7 @@ Preload.prototype.init = function (options) {
             var results = data
             this.data[source] = results.results ? results.results : results
           } catch (e) {
-            console.log('Preload Load Error:', datasource.name, requestUrl)
+            console.log('Preload Load Error:', datasource.name)
             console.log(e)
           }
         }

--- a/dadi/lib/datasource/route-validator.js
+++ b/dadi/lib/datasource/route-validator.js
@@ -30,7 +30,7 @@ RouteValidator.prototype.get = function (route, param, options, req) {
     return datasource.provider.load(req.url, (err, data) => {
       if (err) return reject(err)
 
-      if (datasource.provider.destroy) {
+      if (datasource.provider && datasource.provider.destroy) {
         datasource.provider.destroy()
       }
 

--- a/dadi/lib/datasource/route-validator.js
+++ b/dadi/lib/datasource/route-validator.js
@@ -20,15 +20,20 @@ RouteValidator.prototype.get = function (route, param, options, req) {
       })
     }
 
-    var requestUrl = datasource.processRequest(route.path, req)
-
     datasource.provider = new Providers[datasource.source.type]()
     datasource.provider.initialise(datasource, datasource.schema)
 
-    return datasource.provider.load(requestUrl, (err, data) => {
+    // var requestUrl = datasource.processRequest(route.path, req)
+    datasource.processRequest(route.path, req)
+
+    // return datasource.provider.load(requestUrl, (err, data) => {
+    return datasource.provider.load(req.url, (err, data) => {
       if (err) return reject(err)
 
-      datasource.provider.destroy()
+      if (datasource.provider.destroy) {
+        datasource.provider.destroy()
+      }
+
       datasource.provider = null
 
       // TODO: simplify this, doesn't require a try/catch

--- a/dadi/lib/datasource/route-validator.js
+++ b/dadi/lib/datasource/route-validator.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var Datasource = require(path.join(__dirname, '/../datasource'))
+var Providers = require(path.join(__dirname, '/../providers'))
 
 var RouteValidator = function () {
   this.validationDatasources = {}
@@ -19,14 +20,21 @@ RouteValidator.prototype.get = function (route, param, options, req) {
       })
     }
 
-    datasource.processRequest(route.path, req)
+    var requestUrl = datasource.processRequest(route.path, req)
 
-    return datasource.provider.load(null, (err, result) => {
+    datasource.provider = new Providers[datasource.source.type]()
+    datasource.provider.initialise(datasource, datasource.schema)
+
+    return datasource.provider.load(requestUrl, (err, data) => {
       if (err) return reject(err)
 
-      if (result) {
+      datasource.provider.destroy()
+      datasource.provider = null
+
+      // TODO: simplify this, doesn't require a try/catch
+      if (data) {
         try {
-          var results = (typeof result === 'object' ? result : JSON.parse(result))
+          var results = data // JSON.parse(data.toString())
 
           if (results.results && results.results.length > 0) {
             return resolve('')
@@ -34,7 +42,7 @@ RouteValidator.prototype.get = function (route, param, options, req) {
             return reject('')
           }
         } catch (e) {
-          console.log('RouteValidator Load Error:', datasource.name, datasource.provider.endpoint)
+          console.log('RouteValidator Load Error:', datasource.name, requestUrl)
           console.log(e)
 
           return reject('')

--- a/dadi/lib/datasource/route-validator.js
+++ b/dadi/lib/datasource/route-validator.js
@@ -47,7 +47,7 @@ RouteValidator.prototype.get = function (route, param, options, req) {
             return reject('')
           }
         } catch (e) {
-          console.log('RouteValidator Load Error:', datasource.name, requestUrl)
+          console.log('RouteValidator Load Error:', datasource.name, req.url)
           console.log(e)
 
           return reject('')

--- a/dadi/lib/providers/remote.js
+++ b/dadi/lib/providers/remote.js
@@ -21,7 +21,7 @@ const RemoteProvider = function () {
   // console.log('RemoteProvider:', RemoteProvider.numInstances)
 }
 
-RemoteProvider.prototype.destroy = function() {
+RemoteProvider.prototype.destroy = function () {
   RemoteProvider.numInstances = (RemoteProvider.numInstances || 0) - 1
 }
 

--- a/dadi/lib/providers/remote.js
+++ b/dadi/lib/providers/remote.js
@@ -15,10 +15,14 @@ const BearerAuthStrategy = require(path.join(__dirname, '/../auth/bearer'))
 const DatasourceCache = require(path.join(__dirname, '/../cache/datasource'))
 
 const RemoteProvider = function () {
-  this.dataCache = DatasourceCache()
+  this.dataCache = new DatasourceCache()
 
   RemoteProvider.numInstances = (RemoteProvider.numInstances || 0) + 1
   // console.log('RemoteProvider:', RemoteProvider.numInstances)
+}
+
+RemoteProvider.prototype.destroy = function() {
+  RemoteProvider.numInstances = (RemoteProvider.numInstances || 0) - 1
 }
 
 /**
@@ -40,9 +44,13 @@ RemoteProvider.prototype.initialise = function initialise (datasource, schema) {
  *
  * @return {void}
  */
-RemoteProvider.prototype.buildEndpoint = function buildEndpoint () {
+RemoteProvider.prototype.buildEndpoint = function buildEndpoint (datasourceParams) {
+  if (!datasourceParams) {
+    datasourceParams = this.schema.datasource
+  }
+
   const apiConfig = config.get('api')
-  const source = this.schema.datasource.source
+  const source = datasourceParams.source
 
   const protocol = source.protocol || 'http'
   const host = source.host || apiConfig.host
@@ -51,16 +59,269 @@ RemoteProvider.prototype.buildEndpoint = function buildEndpoint () {
   const uri = [protocol, '://', host, (port !== '' ? ':' : ''),
     port, '/', this.datasource.source.modifiedEndpoint || source.endpoint].join('')
 
-  this.endpoint = this.processDatasourceParameters(this.schema, uri)
+  return this.processDatasourceParameters(datasourceParams, uri)
 }
 
 /**
- * getHeaders
+ * Load data from the specified datasource
  *
+ * @param  {string} requestUrl - datasource endpoint to load
+ * @param  {fn} done - callback on error or completion
+ */
+RemoteProvider.prototype.load = function (requestUrl, done) {
+  this.options = {
+    protocol: this.datasource.source.protocol || config.get('api.protocol'),
+    host: this.datasource.source.host || config.get('api.host'),
+    port: this.datasource.source.port || config.get('api.port'),
+    // path: url.parse(this.endpoint).path,
+    path: url.parse(requestUrl).path,
+    method: 'GET'
+  }
+
+  this.options.agent = this.keepAliveAgent(this.options.protocol)
+  this.options.protocol = this.options.protocol + ':'
+
+  var cacheOptions = {
+    name: this.datasource.name,
+    caching: this.schema.datasource.caching,
+    endpoint: requestUrl // this.endpoint
+  }
+
+  this.dataCache.getFromCache(cacheOptions, (cachedData) => {
+    // data found in the cache, parse into JSON
+    // and return to whatever called load()
+    if (cachedData) {
+      try {
+        cachedData = JSON.parse(cachedData.toString())
+        return done(null, cachedData)
+      } catch (err) {
+        log.error('Remote: cache data incomplete, making HTTP request: ' + err + '(' + cacheOptions.endpoint + ')')
+      }
+    }
+
+    debug('load %s', requestUrl)
+
+    this.getHeaders((err, headers) => {
+      err && done(err)
+
+      this.options = _.extend(this.options, headers)
+
+      log.info({module: 'remote'}, 'GET datasource "' + this.datasource.schema.datasource.key + '": ' + decodeURIComponent(requestUrl))
+
+      const agent = (this.options.protocol === 'https') ? https : http
+
+      let request = agent.request(this.options)
+
+      request.on('response', (res) => {
+        this.handleResponse(requestUrl, res, done)
+      })
+
+      request.on('error', (err) => {
+        const message = err.toString() + ". Couldn't request data from " + requestUrl
+
+        err.name = 'GetData'
+        err.message = message
+        err.remoteIp = this.options.host
+        err.remotePort = this.options.port
+        return done(err)
+      })
+
+      request.end()
+    })
+  })
+}
+
+/**
+ * Takes the response from the server and turns it into a Buffer,
+ * decompressing it if required. Calls processOutput() with the Buffer.
+ *
+ * @param {http.ServerResponse} res - the full HTTP response
  * @param  {fn} done - callback
  * @return {void}
  */
-RemoteProvider.prototype.getHeaders = function getHeaders (done) {
+RemoteProvider.prototype.handleResponse = function (requestUrl, res, done) {
+  setImmediate(() => {
+    var encoding = res.headers['content-encoding'] ? res.headers['content-encoding'] : ''
+    var buffers = []
+    var output
+
+    if (encoding === 'gzip') {
+      const gunzip = zlib.createGunzip()
+
+      gunzip.on('data', (data) => {
+        buffers.push(data)
+      }).on('end', () => {
+        output = Buffer.concat(buffers)
+
+        this.processOutput(requestUrl, res, output, (err, data, res) => {
+          if (err) return done(err)
+          return done(null, data, res)
+        })
+      }).on('error', (err) => {
+        done(err)
+      })
+
+      res.pipe(gunzip)
+    } else {
+      res.on('data', (chunk) => {
+        buffers.push(chunk)
+      })
+
+      res.on('end', () => {
+        output = Buffer.concat(buffers)
+
+        this.processOutput(requestUrl, res, output, (err, data, res) => {
+          if (err) return done(err)
+          return done(null, data, res)
+        })
+      })
+    }
+  })
+}
+
+/**
+ * Processes the response from the server, caching it if it's a 200
+ *
+ * @param {http.ServerResponse} res - the full HTTP response
+ * @param {Buffer} data - the body of the response as a Buffer
+ * @param {fn} done - the method to call when finished, accepts args (err, data, res)
+ */
+RemoteProvider.prototype.processOutput = function (requestUrl, res, data, done) {
+  setImmediate(() => {
+    // Return a 202 Accepted response immediately,
+    // along with the datasource response
+    if (res.statusCode === 202) {
+      return done(null, JSON.parse(data.toString()), res)
+    }
+
+    // return 5xx error as the datasource response
+    if (res.statusCode && /^5/.exec(res.statusCode)) {
+      data = {
+        'results': [],
+        'errors': [{
+          'code': 'WEB-0005',
+          'title': 'Datasource Timeout',
+          'details': "The datasource '" + this.datasource.name + "' timed out: " + res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint
+        }]
+      }
+    } else if (res.statusCode === 404) {
+      data = {
+        'results': [],
+        'errors': [{
+          'code': 'WEB-0004',
+          'title': 'Datasource Not Found',
+          'details': 'Datasource "' + this.datasource.name + '" failed. ' + res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint
+        }]
+      }
+    } else if (res.statusCode && !/200|400/.exec(res.statusCode)) {
+      // if the error is anything other than Success or Bad Request, error
+      const err = new Error()
+      err.message = 'Datasource "' + this.datasource.name + '" failed. ' + res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint
+      if (data) err.message += '\n' + data.toString()
+
+      err.remoteIp = this.options.host
+      err.remotePort = this.options.port
+
+      log.error({module: 'remote'}, res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint)
+
+      console.log(err)
+      // return done(err)
+      throw (err)
+    }
+
+    // Cache 200 responses
+    if (res.statusCode === 200) {
+      log.info(
+        {module: 'remote'},
+        'GOT datasource "' +
+        this.datasource.schema.datasource.key +
+        '": ' + decodeURIComponent(requestUrl) +
+        ' (HTTP 200, ' +
+        require('humanize-plus').fileSize(Buffer.byteLength(data)) + ')'
+      )
+
+      // log.info(
+      //   {module: 'remote'}, '> CALL cacheResponse ' +  requestUrl + ' ' + this.dataCache.stillCaching)
+
+      var cacheOptions = {
+        name: this.datasource.name,
+        caching: this.schema.datasource.caching,
+        endpoint: requestUrl // this.endpoint
+      }
+
+      this.dataCache.cacheResponse(cacheOptions, data, written => {
+        // console.log(typeof data, Buffer.isBuffer(data))
+        // console.log(written, this.dataCache.stillCaching)
+        return done(null, JSON.parse(data.toString()))
+      })
+    } else {
+      if (Buffer.isBuffer(data)) {
+        data = data.toString()
+      }
+
+      if (typeof data === 'string') {
+        data = JSON.parse(data)
+      }
+
+      return done(null, data)
+    }
+  })
+}
+
+/**
+ * Called on every request, rebuilds the datasource endpoint
+ *
+ * @param  {http.IncomingMessage} req - the full HTTP request object
+ */
+RemoteProvider.prototype.processRequest = function (datasourceParams) {
+  return this.buildEndpoint(datasourceParams)
+}
+
+/**
+ * Adds querystring parameters to the datasource endpoint using
+ * properties defined in the schema
+ *
+ * @param  {Object} schema - the datasource schema
+ * @param  {type} uri - the original datasource endpoint
+ * @returns {string} uri with query string appended
+ */
+RemoteProvider.prototype.processDatasourceParameters = function (datasourceParams, uri) {
+  debug('processDatasourceParameters %s', uri)
+
+  let query = (uri.indexOf('?') > 0) ? '&' : '?'
+
+  const params = [
+    { 'count': (datasourceParams.count || 0) },
+    { 'skip': (datasourceParams.skip) },
+    { 'page': (datasourceParams.page || 1) },
+    { 'filter': datasourceParams.filter || {} },
+    { 'fields': datasourceParams.fields || {} },
+    { 'sort': this.processSortParameter(datasourceParams.sort) }
+  ]
+
+  // pass cache flag to API endpoint
+  if (datasourceParams.hasOwnProperty('cache')) {
+    params.push({ 'cache': datasourceParams.cache })
+  }
+
+  params.forEach((param) => {
+    for (let key in param) {
+      if (param.hasOwnProperty(key) && (typeof param[key] !== 'undefined')) {
+        query = query + key + '=' + (_.isObject(param[key]) ? JSON.stringify(param[key]) : param[key]) + '&'
+      }
+    }
+  })
+
+  return uri + query.slice(0, -1)
+}
+
+/**
+ * Requests an Authorization token and sets up the request headers
+ * with encoding and Authorization values
+ *
+ * @param  {fn} done - returns the request headers
+ */
+RemoteProvider.prototype.getHeaders = function (done) {
   var headers = {
     'accept-encoding': 'gzip'
   }
@@ -121,217 +382,15 @@ RemoteProvider.prototype.getHeaders = function getHeaders (done) {
 }
 
 /**
- * handleResponse
+ * Returns http|https keepAliveAgent depending on specified protocol
  *
- * @param  {response} res - response
- * @param  {fn} done - callback
- * @return {void}
+ * @param  {string} protocol - the protocol for the current request
+ * @returns {module} http|https keepAliveAgent
  */
-RemoteProvider.prototype.handleResponse = function handleResponse (res, done) {
-  const encoding = res.headers['content-encoding'] ? res.headers['content-encoding'] : ''
-  let output = ''
-
-  if (encoding === 'gzip') {
-    const gunzip = zlib.createGunzip()
-    const buffer = []
-
-    gunzip.on('data', (data) => {
-      buffer.push(data.toString())
-    }).on('end', () => {
-      output = buffer.join('')
-      this.processOutput(res, output, (err, data, res) => {
-        if (err) return done(err)
-        return done(null, data, res)
-      })
-    }).on('error', (err) => {
-      done(err)
-    })
-
-    res.pipe(gunzip)
-  } else {
-    res.on('data', (chunk) => {
-      output += chunk
-    })
-
-    res.on('end', () => {
-      this.processOutput(res, output, (err, data, res) => {
-        if (err) return done(err)
-        return done(null, data, res)
-      })
-    })
-  }
-}
-
-/**
- * keepAliveAgent - returns http|https module depending on config
- *
- * @param  {string} protocol
- * @return {module} http|https
- */
-RemoteProvider.prototype.keepAliveAgent = function keepAliveAgent (protocol) {
+RemoteProvider.prototype.keepAliveAgent = function (protocol) {
   return (protocol === 'https')
     ? new https.Agent({ keepAlive: true })
     : new http.Agent({ keepAlive: true })
-}
-
-/**
- * load - loads data form the datasource
- *
- * @param  {string} requestUrl - url of the web request (not used)
- * @param  {fn} done - callback on error or completion
- * @return {void}
- */
-RemoteProvider.prototype.load = function (requestUrl, done) {
-  this.requestUrl = requestUrl
-
-  this.options = {
-    protocol: this.datasource.source.protocol || config.get('api.protocol'),
-    host: this.datasource.source.host || config.get('api.host'),
-    port: this.datasource.source.port || config.get('api.port'),
-    path: url.parse(this.endpoint).path,
-    method: 'GET'
-  }
-
-  this.options.agent = this.keepAliveAgent(this.options.protocol)
-  this.options.protocol = this.options.protocol + ':'
-
-  this.dataCache.getFromCache(this.datasource, (cachedData) => {
-    if (cachedData) return done(null, cachedData)
-
-    debug('load %s', this.endpoint)
-
-    this.getHeaders((err, headers) => {
-      err && done(err)
-
-      this.options = _.extend(this.options, headers)
-
-      log.info({module: 'remote'}, "GET datasource '" + this.datasource.schema.datasource.key + "': " + this.options.path)
-
-      const agent = (this.options.protocol === 'https') ? https : http
-      let request = agent.request(this.options, (res) => {
-        this.handleResponse(res, done)
-      })
-
-      request.on('error', (err) => {
-        const message = err.toString() + ". Couldn't request data from " + this.datasource.endpoint
-        err.name = 'GetData'
-        err.message = message
-        err.remoteIp = this.options.host
-        err.remotePort = this.options.port
-        return done(err)
-      })
-
-      request.end()
-    })
-  })
-}
-
-/**
- * processDatasourceParameters - adds querystring parameters to the datasource endpoint using properties defined in the schema
- *
- * @param  {Object} schema - the datasource schema
- * @param  {type} uri - the original datasource endpoint
- * @returns {string} uri with query string appended
- */
-RemoteProvider.prototype.processDatasourceParameters = function processDatasourceParameters (schema, uri) {
-  debug('processDatasourceParameters %s', uri)
-
-  let query = (uri.indexOf('?') > 0) ? '&' : '?'
-
-  const params = [
-    { 'count': (schema.datasource.count || 0) },
-    { 'skip': (schema.datasource.skip) },
-    { 'page': (schema.datasource.page || 1) },
-    { 'referer': schema.datasource.referer },
-    { 'filter': schema.datasource.filter || {} },
-    { 'fields': schema.datasource.fields || {} },
-    { 'sort': this.processSortParameter(schema.datasource.sort) }
-  ]
-
-  // pass cache flag to API endpoint
-  if (schema.datasource.hasOwnProperty('cache')) {
-    params.push({ 'cache': schema.datasource.cache })
-  }
-
-  params.forEach((param) => {
-    for (let key in param) {
-      if (param.hasOwnProperty(key) && (typeof param[key] !== 'undefined')) {
-        query = query + key + '=' + (_.isObject(param[key]) ? JSON.stringify(param[key]) : param[key]) + '&'
-      }
-    }
-  })
-
-  return uri + query.slice(0, -1)
-}
-
-/**
- * processOutput
- *
- * @param  {response} res
- * @param  {string} data
- * @param  {fn} done
- * @return {void}
- */
-RemoteProvider.prototype.processOutput = function processOutput (res, data, done) {
-  // Return a 202 Accepted response immediately,
-  // along with the datasource response
-  if (res.statusCode === 202) {
-    return done(null, JSON.parse(data), res)
-  }
-
-  // return 5xx error as the datasource response
-  if (res.statusCode && /^5/.exec(res.statusCode)) {
-    data = {
-      'results': [],
-      'errors': [{
-        'code': 'WEB-0005',
-        'title': 'Datasource Timeout',
-        'details': "The datasource '" + this.datasource.name + "' timed out: " + res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint
-      }]
-    }
-  } else if (res.statusCode === 404) {
-    data = {
-      'results': [],
-      'errors': [{
-        'code': 'WEB-0004',
-        'title': 'Datasource Not Found',
-        'details': 'Datasource "' + this.datasource.name + '" failed. ' + res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint
-      }]
-    }
-  } else if (res.statusCode && !/200|400/.exec(res.statusCode)) {
-    // if the error is anything other than Success or Bad Request, error
-    const err = new Error()
-    err.message = 'Datasource "' + this.datasource.name + '" failed. ' + res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint
-    if (data) err.message += '\n' + data
-
-    err.remoteIp = this.options.host
-    err.remotePort = this.options.port
-
-    log.error({module: 'remote'}, res.statusMessage + ' (' + res.statusCode + ')' + ': ' + this.endpoint)
-
-    console.log(err)
-    // return done(err)
-    throw (err)
-  }
-
-  // Cache 200 responses
-  if (res.statusCode === 200) {
-    this.dataCache.cacheResponse(this.datasource, data, written => {
-      return done(null, data)
-    })
-  } else {
-    return done(null, data)
-  }
-}
-
-/**
- * processRequest - called on every request, rebuild buildEndpoint
- *
- * @param  {obj} req - web request object
- * @return {void}
- */
-RemoteProvider.prototype.processRequest = function processRequest (req) {
-  this.buildEndpoint()
 }
 
 /**

--- a/dadi/lib/providers/rss.js
+++ b/dadi/lib/providers/rss.js
@@ -84,7 +84,7 @@ RSSProvider.prototype.load = function load (requestUrl, done) {
           cachedData = JSON.parse(cachedData.toString())
           return done(null, cachedData)
         } catch (err) {
-          log.error('RSS: cache data incomplete, making HTTP request: ' + err + '(' + cacheOptions.cacheKey + ')')
+          console.error('RSS: cache data incomplete, making HTTP request: ' + err + '(' + cacheOptions.cacheKey + ')')
         }
       }
 

--- a/dadi/lib/providers/twitter.js
+++ b/dadi/lib/providers/twitter.js
@@ -71,7 +71,7 @@ TwitterProvider.prototype.load = function load (requestUrl, done) {
           cachedData = JSON.parse(cachedData.toString())
           return done(null, cachedData)
         } catch (err) {
-          log.error('Twitter: cache data incomplete, making HTTP request: ' + err + '(' + cacheOptions.cacheKey + ')')
+          console.error('Twitter: cache data incomplete, making HTTP request: ' + err + '(' + cacheOptions.cacheKey + ')')
         }
       }
 

--- a/dadi/lib/providers/wordpress.js
+++ b/dadi/lib/providers/wordpress.js
@@ -161,7 +161,8 @@ WordPressProvider.prototype.processOutput = function processOutput (res, data, d
  * @return {void}
  */
 WordPressProvider.prototype.processRequest = function processRequest (req) {
-  return this.buildEndpoint(req)
+  // return this.buildEndpoint(req)
+  this.buildEndpoint(req)
 }
 
 /**

--- a/dadi/lib/providers/wordpress.js
+++ b/dadi/lib/providers/wordpress.js
@@ -20,6 +20,7 @@ WordPressProvider.prototype.initialise = function initialise (datasource, schema
   this.datasource = datasource
   this.schema = schema
   this.setAuthStrategy()
+  this.processSchemaParams = false
   this.wordpressApi = new Purest({
     provider: 'wordpress',
     version: 'v1.1'
@@ -32,7 +33,7 @@ WordPressProvider.prototype.initialise = function initialise (datasource, schema
  * @param  {obj} req - web request object
  * @return {void}
  */
-WordPressProvider.prototype.buildEndpoint = function buildEndpoint (req) {
+WordPressProvider.prototype.buildEndpoint = function (req) {
   const endpointParams = this.schema.datasource.endpointParams || []
   const endpoint = this.schema.datasource.source.endpoint
 
@@ -80,15 +81,28 @@ WordPressProvider.prototype.buildQueryParams = function buildQueryParams () {
  * @param  {fn} done - callback on error or completion
  * @return {void}
  */
-WordPressProvider.prototype.load = function load (requestUrl, done) {
+WordPressProvider.prototype.load = function (requestUrl, done) {
   try {
     const queryParams = this.buildQueryParams()
 
     this.cacheKey = [this.endpoint, encodeURIComponent(JSON.stringify(this.schema.datasource))].join('+')
-    this.dataCache = DatasourceCache()
+    this.dataCache = new DatasourceCache()
 
-    this.dataCache.getFromCache(this.datasource, (cachedData) => {
-      if (cachedData) return done(null, cachedData)
+    var cacheOptions = {
+      name: this.datasource.name,
+      caching: this.schema.datasource.caching,
+      cacheKey: this.cacheKey
+    }
+
+    this.dataCache.getFromCache(cacheOptions, (cachedData) => {
+      if (cachedData) {
+        try {
+          cachedData = JSON.parse(cachedData.toString())
+          return done(null, cachedData)
+        } catch (err) {
+          log.error('Wordpress: cache data incomplete, making HTTP request: ' + err + '(' + cacheOptions.cacheKey + ')')
+        }
+      }
 
       this.wordpressApi.query()
         .select(this.endpoint)
@@ -125,8 +139,14 @@ WordPressProvider.prototype.processOutput = function processOutput (res, data, d
     return done(err)
   }
 
+  var cacheOptions = {
+    name: this.datasource.name,
+    caching: this.schema.datasource.caching,
+    cacheKey: this.cacheKey
+  }
+
   if (res.statusCode === 200) {
-    this.dataCache.cacheResponse(this.datasource, JSON.stringify(data), () => {
+    this.dataCache.cacheResponse(cacheOptions, JSON.stringify(data), () => {
       //
     })
   }
@@ -141,7 +161,7 @@ WordPressProvider.prototype.processOutput = function processOutput (res, data, d
  * @return {void}
  */
 WordPressProvider.prototype.processRequest = function processRequest (req) {
-  this.buildEndpoint(req)
+  return this.buildEndpoint(req)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/web",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Web frontend and template layer for @dadi/api",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "event-stream": "^3.3.1",
     "express-session": "1.12.1",
     "feedparser": "^1.1.4",
+    "humanize-plus": "^1.8.2",
     "js-beautify": "^1.5.10",
     "json5": "0.2.0",
     "kinesis": "^1.2.2",

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -279,7 +279,7 @@ describe('Controller', function (done) {
             var call = providerSpy.secondCall
             var provider = call.thisValue
 
-            var q = require('url').parse(provider.endpoint, true).query
+            var q = require('url').parse(provider.options.path, true).query
             var filter = q.filter
             var filterObj = JSON.parse(filter)
             should.exist(filterObj._id)
@@ -333,15 +333,19 @@ describe('Controller', function (done) {
 
             var filterDatasource = providerSpy.thisValues[1]
 
+            var q = require('url').parse(filterDatasource.options.path, true).query
+            var filter = q.filter
+            var filterObj = JSON.parse(filter)
+
             filterDatasource.schema.datasource.filterEventResult.should.exist
             filterDatasource.schema.datasource.filterEventResult.x.should.exist
             filterDatasource.schema.datasource.filterEventResult.x.should.eql('1')
 
-            filterDatasource.schema.datasource.filter.x.should.exist
-            filterDatasource.schema.datasource.filter.x.should.eql('1')
+            filterObj.x.should.exist
+            filterObj.x.should.eql('1')
 
-            filterDatasource.schema.datasource.filter.y.should.exist
-            filterDatasource.schema.datasource.filter.y.should.eql('2')
+            filterObj.y.should.exist
+            filterObj.y.should.eql('2')
 
             done()
           })

--- a/test/unit/data-providers.js
+++ b/test/unit/data-providers.js
@@ -102,7 +102,10 @@ describe('Data Providers', function (done) {
             .end((err, res) => {
               providerSpy.restore()
               providerSpy.called.should.eql(true)
-              providerSpy.firstCall.args[1].should.eql(text)
+
+              var buffer = providerSpy.firstCall.args[2]
+
+              buffer.toString().should.eql(text)
 
               done()
             })
@@ -602,7 +605,7 @@ describe('Data Providers', function (done) {
           TestHelper.startServer(pages).then(() => {
             var connectionString = 'http://' + config.get('server.host') + ':' + config.get('server.port')
             var client = request(connectionString)
-
+            console.log(pages[0].routes[0].path)
             client
             .get(pages[0].routes[0].path + '?json=true')
             .end((err, res) => {

--- a/test/unit/datasource.js
+++ b/test/unit/datasource.js
@@ -178,7 +178,8 @@ describe('Datasource', function (done) {
     var dsName = 'car-makes'
 
     new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
-      ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+      console.log(ds)
+      ds.processRequest(dsName).should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
   })
@@ -193,8 +194,8 @@ describe('Datasource', function (done) {
 
     new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
       ds.schema.datasource.skip = 5
-      ds.processRequest(dsName, req)
-      ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&skip=5&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+      var u = ds.processRequest(dsName, req)
+      u.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&skip=5&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
   })
@@ -205,7 +206,9 @@ describe('Datasource', function (done) {
     var dsName = 'car-makes'
 
     new Datasource(null, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
-      ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+      console.log(ds)
+      var u = ds.processRequest(dsName, {})
+      u.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
   })

--- a/test/unit/datasource.js
+++ b/test/unit/datasource.js
@@ -178,8 +178,8 @@ describe('Datasource', function (done) {
     var dsName = 'car-makes'
 
     new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
-      console.log(ds)
-      ds.processRequest(dsName).should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+      ds.provider.buildEndpoint()
+      ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
   })
@@ -194,8 +194,8 @@ describe('Datasource', function (done) {
 
     new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
       ds.schema.datasource.skip = 5
-      var u = ds.processRequest(dsName, req)
-      u.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&skip=5&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+      ds.provider.buildEndpoint()
+      ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&skip=5&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
   })
@@ -206,9 +206,8 @@ describe('Datasource', function (done) {
     var dsName = 'car-makes'
 
     new Datasource(null, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
-      console.log(ds)
-      var u = ds.processRequest(dsName, {})
-      u.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+      ds.provider.buildEndpoint()
+      ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
   })
@@ -224,7 +223,7 @@ describe('Datasource', function (done) {
     new Datasource(null, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
       delete ds.schema.datasource.source.host
       // delete ds.schema.datasource.source.port
-      ds.provider.buildEndpoint(ds.schema, function () {})
+      ds.provider.buildEndpoint()
       ds.provider.endpoint.should.eql('http://api.example.com:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
@@ -240,7 +239,7 @@ describe('Datasource', function (done) {
 
     new Datasource(null, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
       delete ds.schema.datasource.source.port
-      ds.provider.buildEndpoint(ds.schema, function () {})
+      ds.provider.buildEndpoint()
       ds.provider.endpoint.should.eql('http://127.0.0.1:80/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
@@ -257,7 +256,7 @@ describe('Datasource', function (done) {
     new Datasource(null, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
       delete ds.schema.datasource.source.host
       delete ds.schema.datasource.source.port
-      ds.provider.buildEndpoint(ds.schema, function () {})
+      ds.provider.buildEndpoint()
       ds.provider.endpoint.should.eql('http://api.example.com:80/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
       done()
     })
@@ -352,9 +351,9 @@ describe('Datasource', function (done) {
       new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
         var params = { 'make': 'bmw' }
         var req = { params: params, url: '/1.0/cars/makes' }
-        var endpoint = ds.provider.processDatasourceParameters(dsSchema, req.url)
+        ds.provider.processDatasourceParameters(dsSchema, req.url)
         Datasource.Datasource.prototype.loadDatasource.restore()
-        endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+        decodeURIComponent(require('url').parse(ds.provider.endpoint).path).should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
         done()
       })
     })
@@ -373,9 +372,9 @@ describe('Datasource', function (done) {
       new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
         var params = { 'make': 'bmw' }
         var req = { params: params, url: '/1.0/cars/makes' }
-        var endpoint = ds.provider.processDatasourceParameters(dsSchema, req.url)
+        ds.provider.processDatasourceParameters(dsSchema, req.url)
         Datasource.Datasource.prototype.loadDatasource.restore()
-        endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1,"age":-1}')
+        decodeURIComponent(require('url').parse(ds.provider.endpoint).path).should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1,"age":-1}')
         done()
       })
     })
@@ -394,10 +393,10 @@ describe('Datasource', function (done) {
       new Datasource(p, dsName, options).init(function (err, ds) {
         var params = { 'make': 'bmw' }
         var req = { params: params, url: '/1.0/cars/makes' }
-        var endpoint = ds.provider.processDatasourceParameters(dsSchema, req.url)
+        ds.provider.processDatasourceParameters(dsSchema, req.url)
         Datasource.Datasource.prototype.loadDatasource.restore()
 
-        endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+        decodeURIComponent(require('url').parse(ds.provider.endpoint).path).should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
         done()
       })
     })
@@ -416,10 +415,10 @@ describe('Datasource', function (done) {
       new Datasource(p, dsName, options).init(function (err, ds) {
         var params = { 'make': 'bmw' }
         var req = { params: params, url: '/1.0/cars/makes' }
-        var endpoint = ds.provider.processDatasourceParameters(dsSchema, req.url)
+        ds.provider.processDatasourceParameters(dsSchema, req.url)
 
         Datasource.Datasource.prototype.loadDatasource.restore()
-        endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
+        decodeURIComponent(require('url').parse(ds.provider.endpoint).path).should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}')
         done()
       })
     })
@@ -438,9 +437,9 @@ describe('Datasource', function (done) {
       new Datasource(p, dsName, options).init(function (err, ds) {
         var params = { 'make': 'bmw' }
         var req = { params: params, url: '/1.0/cars/makes' }
-        var endpoint = ds.provider.processDatasourceParameters(dsSchema, req.url)
+        ds.provider.processDatasourceParameters(dsSchema, req.url)
         Datasource.Datasource.prototype.loadDatasource.restore()
-        endpoint.should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1,"age":-1}')
+        decodeURIComponent(require('url').parse(ds.provider.endpoint).path).should.eql('/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1,"age":-1}')
         done()
       })
     })
@@ -553,7 +552,7 @@ describe('Datasource', function (done) {
       new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
         ds.processRequest(dsName, req)
         ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=3&filter={"name":"bmw"}&fields={"name":1,"_id":0}&sort={"name":1}&cache=false')
-        ds.schema.datasource.cache.should.eql(false)
+        // ds.schema.datasource.cache.should.eql(false)
         done()
       })
     })
@@ -571,12 +570,13 @@ describe('Datasource', function (done) {
       new Datasource(p, dsName, TestHelper.getPathOptions()).init(function (err, ds) {
         ds.processRequest(dsName, req)
         ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=3&filter={"name":"bmw"}&fields={"name":1,"_id":0}&sort={"name":1}&cache=false')
-        ds.schema.datasource.cache.should.eql(false)
+        // ds.schema.datasource.cache.should.eql(false)
 
         req = { params: params, url: '/1.0/cars/makes' }
         ds.processRequest(dsName, req)
         ds.provider.endpoint.should.eql('http://127.0.0.1:3000/1.0/cars/makes?count=20&page=3&filter={"name":"bmw"}&fields={"name":1,"_id":0}&sort={"name":1}')
-        ;(typeof ds.schema.datasource.cache === 'undefined').should.eql(true)
+
+        // ;(typeof ds.schema.datasource.cache === 'undefined').should.eql(true)
 
         done()
       })


### PR DESCRIPTION
This PR modifies the controller to make it initialise each datasource's data provider just before it is used, then destroy it after the data is returned.

It is an attempt to resolve the issue seen under load where a provider instance is returned data meant for another. The original suspect of this problem was the cache module, that no longer appears to be the case, as the issue can be reproduced with caching disabled.