### PR TITLE
Add support for custom environments

### DIFF
--- a/config.js
+++ b/config.js
@@ -417,7 +417,7 @@ var conf = convict({
   },
   env: {
     doc: 'The applicaton environment.',
-    format: ['production', 'development', 'test', 'qa'],
+    format: String,
     default: 'development',
     env: 'NODE_ENV',
     arg: 'node_env'


### PR DESCRIPTION
Closes #184.

I thought about adding a custom error message for when we try to use an environment for which there's no config, but the default `ENOENT` error is actually quite descriptive and informs the user the path of the file it's expecting.