### PR TITLE
Update post-install script to include reference to Dust engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@dadi/metadata": "^1.0.0",
     "@dadi/passport": "latest",
     "@dadi/status": "latest",
+    "@dadi/web-dustjs": "latest",
     "@purest/providers": "^1.0.0",
     "async": "^2.3.0",
     "body-parser": "^1.11.0",
@@ -91,8 +92,7 @@
     "superagent-mock": "^3.3.0",
     "supertest": "latest",
     "uuid": "^3.0.1",
-    "validate-commit-msg": "^2.12.1",
-    "@dadi/web-dustjs": "latest"
+    "validate-commit-msg": "^2.12.1"
   },
   "repository": {
     "type": "git",

--- a/scripts/init-web.js
+++ b/scripts/init-web.js
@@ -14,7 +14,7 @@ if (~currentPath.indexOf('node_modules')) {
   fs.stat(destinationFile, (err, stats) => {
     if (err && err.code && err.code === 'ENOENT') {
       // file doesn't exist
-      fs.writeFile(destinationFile, "require('@dadi/web')", function(err) {
+      fs.writeFile(destinationFile, "require('@dadi/web')({engines:[require('@dadi/web-dustjs')]})", function(err) {
         if (err) return console.log(err)
         console.log('Web entry point created at', destinationFile)
       })


### PR DESCRIPTION
This PR fixes the install script to create a `server.js` with the correct syntax for 3.0.