### PR TITLE
Minor updates to template store

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -467,8 +467,7 @@ Server.prototype.loadApi = function (options, reload, callback) {
           package: '@dadi/web',
           version: version,
           healthCheck: {
-            baseUrl:
-              'http://' +
+            baseUrl: 'http://' +
               config.get('server.host') +
               ':' +
               config.get('server.port'),
@@ -921,7 +920,8 @@ function onListening (e) {
     var env = config.get('env')
     var protocol = config.get('server.protocol') || 'http'
     var redirectPort = config.get('server.redirectPort')
-    var engine = Object.keys(config.get('engines')) || 'Not found!'.red
+    var engines = Object.keys(templateStore.getEngines())
+    var enginesInfo = engines.length ? engines.join(', ') : 'None'.red
     var extraPadding = (redirectPort > 0 && '          ') || ''
 
     var startText = '\n'
@@ -962,7 +962,7 @@ function onListening (e) {
     startText += '  Version:     '.green + extraPadding + version + '\n'
     startText += '  Node.JS:     '.green + extraPadding + nodeVersion + '\n'
     startText += '  Environment: '.green + extraPadding + env + '\n'
-    startText += '  Engine:      '.green + extraPadding + engine + '\n'
+    startText += '  Engine:      '.green + extraPadding + enginesInfo + '\n'
 
     if (config.get('api.enabled') === true) {
       startText +=

--- a/dadi/lib/templates/store.js
+++ b/dadi/lib/templates/store.js
@@ -73,6 +73,15 @@ TemplateStore.prototype.get = function (templateName) {
 }
 
 /**
+  * Retrieves the engines object.
+  *
+  * @return {Object} The engines object.
+  */
+TemplateStore.prototype.getEngines = function () {
+  return this.engines
+}
+
+/**
   * Computes the list of file extensions supported by all engines.
   *
   * @return {Array} An array of extensions.
@@ -206,9 +215,7 @@ TemplateStore.prototype.loadFiles = function (files, options) {
           )
         })
       })
-    },
-
-    extensions: this.getSupportedExtensions()
+    }
   })
 }
 
@@ -243,7 +250,6 @@ TemplateStore.prototype.loadPages = function (pages, options) {
 
   return helpers
     .readDirectory(this.pagesPath, {
-      extensions: this.getSupportedExtensions(),
       recursive: true
     })
     .then(files => {


### PR DESCRIPTION
This PR:

- Throws an error when the pages directory contains templates without an engine that can handle them. This happens at boot time, as opposed to the current version which throws a (not very helpful) error when accessing the problematic page;

- Fixes an issue where information about the loaded engines on the app boot screen was sometimes incorrect.