### PR TITLE
♻️ Reflect template and event changes without restarting app

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -523,8 +523,7 @@ Server.prototype.loadApi = function (options, reload, callback) {
     this.addMonitor(options.pagePath, pageFile => {
       this.updatePages(options.pagePath, options, true)
       this.compile(options)
-
-      templateStore.reInitilise()
+      templateStore.reInitialise()
     })
 
     this.addMonitor(options.routesPath, file => {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -523,6 +523,8 @@ Server.prototype.loadApi = function (options, reload, callback) {
     this.addMonitor(options.pagePath, pageFile => {
       this.updatePages(options.pagePath, options, true)
       this.compile(options)
+
+      templateStore.reInitilise()
     })
 
     this.addMonitor(options.routesPath, file => {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -467,7 +467,8 @@ Server.prototype.loadApi = function (options, reload, callback) {
           package: '@dadi/web',
           version: version,
           healthCheck: {
-            baseUrl: 'http://' +
+            baseUrl:
+              'http://' +
               config.get('server.host') +
               ':' +
               config.get('server.port'),
@@ -510,6 +511,12 @@ Server.prototype.loadApi = function (options, reload, callback) {
     })
 
     this.addMonitor(options.eventPath, eventFile => {
+      // Delete the existing cached events
+      Object.keys(require.cache).forEach(i => {
+        if (i.includes(options.eventPath)) delete require.cache[i]
+      })
+
+      // Reload
       this.updatePages(options.pagePath, options, true)
     })
 

--- a/dadi/lib/templates/store.js
+++ b/dadi/lib/templates/store.js
@@ -39,6 +39,31 @@ TemplateStore.prototype.findEngineForExtension = function (extension) {
 }
 
 /**
+  * reInitialise template engines
+  *
+  * @return {Promise} Resolves when all functions finish executing.
+  */
+TemplateStore.prototype.reInitialise = function () {
+  let queue = []
+
+  Object.keys(this.engines).forEach(name => {
+    const engine = this.engines[name]
+
+    engine.handler.initialise()
+
+    if (engine.started) {
+      const finishLoadingFunction = engine.handler.finishLoading
+
+      if (typeof finishLoadingFunction === 'function') {
+        queue.push(finishLoadingFunction.call(engine.handler))
+      }
+    }
+  })
+
+  return Promise.all(queue)
+}
+
+/**
   * Triggers the `finishLoading` function on all templating engines.
   *
   * @return {Promise} Resolves when all functions finish executing.
@@ -393,7 +418,9 @@ TemplateStore.prototype.validateEngine = function (factory, engine) {
 
   if (errors.length) {
     const engineName = factory && factory.metadata && factory.metadata.name
-    const errorMessage = `Validation failed for ${engineName ? engineName + ' ' : ''}templating engine: ${errors.join(', ')}`
+    const errorMessage = `Validation failed for ${engineName
+      ? engineName + ' '
+      : ''}templating engine: ${errors.join(', ')}`
     const error = new Error(errorMessage)
 
     log.error({ module: 'templates' }, { err: error }, errorMessage)


### PR DESCRIPTION
Allows changes to events & template partials/includes to reinitialise the template engine without restarting the app.

Closes #193