### PR TITLE
Match path helper on param content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://dadi.tech/assets/products/dadi-web-full.png" alt="DADI Web" height="65"/>
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/web.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/web)
-[![coverage](https://img.shields.io/badge/coverage-76%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/web)
+[![coverage](https://img.shields.io/badge/coverage-78%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/web)
 [![Build Status](https://travis-ci.org/dadi/web.svg?branch=master)](https://travis-ci.org/dadi/web)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 

--- a/dadi/lib/page/index.js
+++ b/dadi/lib/page/index.js
@@ -1,12 +1,13 @@
+'use strict'
+
 /**
  * @module Page
  */
-var _ = require('underscore')
-var pathToRegexp = require('path-to-regexp')
+const pathToRegexp = require('path-to-regexp')
 
-var _pages = {}
+let _pages = {}
 
-var Page = function (name, schema, hostKey, templateCandidate) {
+const Page = function (name, schema, hostKey, templateCandidate) {
   schema.settings = schema.settings || {}
 
   this.name = name // schema.page.name || name
@@ -47,7 +48,7 @@ var Page = function (name, schema, hostKey, templateCandidate) {
  * @api public
  */
 Page.prototype.constructRoutes = function (schema) {
-  var routes = schema.routes || [{ path: '/' + this.name }]
+  let routes = schema.routes || [{ path: '/' + this.name }]
 
   if (schema.route) {
     if (schema.route.path && typeof schema.route.path === 'string') {
@@ -64,7 +65,7 @@ Page.prototype.constructRoutes = function (schema) {
   }
 
   // add default params to each route
-  _.each(routes, route => {
+  routes.forEach(route => {
     route.params = route.params || []
   })
 
@@ -79,14 +80,20 @@ Page.prototype.constructRoutes = function (schema) {
  * @api public
  */
 Page.prototype.toPath = function (params) {
-  var error
-  var url
+  let error
+  let url
 
   this.routes.forEach(route => {
-    var keys = pathToRegexp(route.path).keys
+    let keys = pathToRegexp(route.path).keys
 
     // only attempt this if the route's parameters match those passed to toPath
-    if (_.difference(_.pluck(keys, 'name'), Object.keys(params)).length === 0) {
+    let matchingKeys = Object.keys(params).every(param => {
+      return keys.filter(key => {
+        key.name === param
+      })
+    })
+
+    if (matchingKeys) {
       try {
         url = pathToRegexp.compile(route.path)(params)
         error = null
@@ -100,7 +107,8 @@ Page.prototype.toPath = function (params) {
     error = new Error(
       'No routes for page "' +
         this.name +
-        '" match the supplied number of parameters'
+        '" match the supplied parameters: ' +
+        JSON.stringify(params)
     )
   }
 
@@ -117,10 +125,10 @@ Page.prototype.toPath = function (params) {
  */
 function checkRouteSetting (schema, name) {
   if (!schema.routes && schema.route && typeof schema.route !== 'object') {
-    var newSchema = schema
+    let newSchema = schema
     newSchema.routes = [{ path: schema.route }]
     delete newSchema.route
-    var message =
+    let message =
       '\nThe `route` property for pages has been extended to provide better routing functionality.\n'
     message +=
       "Please modify the route property for page '" +
@@ -142,7 +150,7 @@ function checkCacheSetting (schema, name) {
     schema.settings.cache = schema.page.cache
     delete schema.page.cache
 
-    var message = '\nThe `cache` property should be nested under `settings`.\n'
+    let message = '\nThe `cache` property should be nested under `settings`.\n'
     message +=
       "Please modify the descriptor file for page '" +
       name +

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "nodeunit": ">=0.5.1",
     "prettier": "^1.1.0",
     "should": "latest",
-    "sinon": "latest",
+    "sinon": "2.x.x",
     "sinon-test": "^1.0.2",
     "snazzy": "^6.0.0",
     "standard": "8.6.0",


### PR DESCRIPTION
When using the @url helper and the toPath method, we're matching page routes to request params using length only. This doesn't work for routes that contain a number of optional params.

This PR changes the test to match routes that have _all_ the params that have been supplied by the request