### PR TITLE
don’t instantiate new DADI Cache for each datasource

### DIFF
--- a/dadi/lib/cache/datasource.js
+++ b/dadi/lib/cache/datasource.js
@@ -7,8 +7,7 @@ var merge = require('deepmerge')
 var path = require('path')
 var url = require('url')
 
-// var Cache = require(path.join(__dirname, '/index.js'))
-var DadiCache = require('@dadi/cache')
+var Cache = require(path.join(__dirname, '/index.js'))
 var config = require(path.join(__dirname, '/../../../config.js'))
 var log = require('@dadi/logger')
 
@@ -17,12 +16,10 @@ var log = require('@dadi/logger')
  * @constructor
  */
 var DatasourceCache = function () {
-  //  this.cache = Cache().cache
   this.cacheOptions = config.get('caching')
-  this.cache = new DadiCache(this.cacheOptions)
+  this.cache = Cache().cache
 
   DatasourceCache.numInstances = (DatasourceCache.numInstances || 0) + 1
-  // console.log('DatasourceCache:', DatasourceCache.numInstances)
 
   var directoryEnabled = this.cacheOptions.directory.enabled
   var redisEnabled = this.cacheOptions.redis.enabled
@@ -153,14 +150,25 @@ DatasourceCache.prototype.cachingEnabled = function (opts) {
  * @param {object} datasource - a datasource schema object containing the datasource settings
  */
 DatasourceCache.prototype.getFilename = function (opts) {
-  var filename = crypto.createHash('sha1').update(opts.name).digest('hex')
+  var filename = crypto
+    .createHash('sha1')
+    .update(opts.name)
+    .digest('hex')
 
   if (opts.cacheKey) {
     filename +=
-      '_' + crypto.createHash('sha1').update(opts.cacheKey).digest('hex')
+      '_' +
+      crypto
+        .createHash('sha1')
+        .update(opts.cacheKey)
+        .digest('hex')
   } else {
     filename +=
-      '_' + crypto.createHash('sha1').update(opts.endpoint).digest('hex')
+      '_' +
+      crypto
+        .createHash('sha1')
+        .update(opts.endpoint)
+        .digest('hex')
   }
 
   return filename

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "istanbul": "^1.1.0-alpha.1",
     "istanbul-cobertura-badger": "^1.1.0",
     "lint-staged": "^3.4.0",
-    "mocha": "latest",
+    "mocha": "3.2.x",
     "nock": "^9.0.13",
     "nodeunit": ">=0.5.1",
     "prettier": "^1.1.0",


### PR DESCRIPTION
> Note: this is a PR to patch the 3.x range of DADI Web

Each datasource load request instantiates a new DADI Cache, which when using Redis creates a new connection to the Redis server. This leads to an enormous number of unreleased connections under load.