### PR TITLE
don’t instantiate new DADI Cache for each datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://dadi.tech/assets/products/dadi-web-full.png" alt="DADI Web" height="65"/>
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/web.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/web)
-[![coverage](https://img.shields.io/badge/coverage-78%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/web)
+[![coverage](https://img.shields.io/badge/coverage-80%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/web)
 [![Build Status](https://travis-ci.org/dadi/web.svg?branch=master)](https://travis-ci.org/dadi/web)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 [![Greenkeeper badge](https://badges.greenkeeper.io/dadi/web.svg)](https://greenkeeper.io/)

--- a/dadi/lib/cache/datasource.js
+++ b/dadi/lib/cache/datasource.js
@@ -7,8 +7,7 @@ var merge = require('deepmerge')
 var path = require('path')
 var url = require('url')
 
-// var Cache = require(path.join(__dirname, '/index.js'))
-var DadiCache = require('@dadi/cache')
+var Cache = require(path.join(__dirname, '/index.js'))
 var config = require(path.join(__dirname, '/../../../config.js'))
 var log = require('@dadi/logger')
 
@@ -17,9 +16,8 @@ var log = require('@dadi/logger')
  * @constructor
  */
 var DatasourceCache = function () {
-  //  this.cache = Cache().cache
   this.cacheOptions = config.get('caching')
-  this.cache = new DadiCache(this.cacheOptions)
+  this.cache = Cache().cache
 
   var directoryEnabled = this.cacheOptions.directory.enabled
   var redisEnabled = this.cacheOptions.redis.enabled

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "fs-extra": "^3.0.1",
     "humanize-plus": "^1.8.2",
     "iltorb": "^1.3.5",
-    "js-beautify": "^1.5.10",
+    "js-beautify": "1.7.3",
     "js-yaml": "^3.7.0",
     "kinesis": "^1.2.2",
     "marked": "^0.3.6",


### PR DESCRIPTION
> Note: this is a PR to patch the latest DADI Web

Each datasource load request instantiates a new DADI Cache, which when using Redis creates a new connection to the Redis server. This leads to an enormous number of unreleased connections under load.