### PR TITLE
Remove underscore string

### DIFF
--- a/dadi/lib/auth/bearer.js
+++ b/dadi/lib/auth/bearer.js
@@ -1,6 +1,5 @@
 var path = require('path')
 var config = require(path.join(__dirname, '/../../../config.js'))
-var help = require(path.join(__dirname, '/../help'))
 var Passport = require('@dadi/passport')
 
 var BearerAuthStrategy = function (options) {
@@ -30,12 +29,12 @@ BearerAuthStrategy.prototype.getToken = function (authStrategy, done) {
     walletOptions: {
       path:
         config.get('paths.tokenWallets') +
-        '/' +
-        help.generateTokenWalletFilename(
-          strategy.host,
-          strategy.port,
-          strategy.credentials.clientId
-        )
+        '/token.' +
+        strategy.host +
+        strategy.port +
+        '.' +
+        strategy.credentials.clientId +
+        '.json'
     }
   })
     .then(function (bearerToken) {

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -260,9 +260,14 @@ module.exports.getToken = function () {
     },
     wallet: 'file',
     walletOptions: {
-      path: `${config.get('paths.tokenWallets')}/token.${config.get(
-        'api.host'
-      )}${config.get('api.port')}.${config.get('auth.clientId')}.json`
+      path:
+        config.get('paths.tokenWallets') +
+        '/token.' +
+        config.get('api.host') +
+        config.get('api.port') +
+        '.' +
+        config.get('auth.clientId') +
+        '.json'
     }
   })
 }

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -244,14 +244,8 @@ module.exports.clearCache = function (req, Cache, callback) {
 }
 
 /**
- * Generates a filename for a token wallet file
- * @param {String} host - Issuer host
- * @param {Number} port - Issuer port
- * @param {String} clientId - Client ID
+ * Uses @dadi/passport to get a token to access a DADI API
  */
-module.exports.generateTokenWalletFilename = function (host, port, clientId) {
-  return `token.${host}${port}.${clientId}.json`
-}
 
 module.exports.getToken = function () {
   return Passport({
@@ -266,14 +260,9 @@ module.exports.getToken = function () {
     },
     wallet: 'file',
     walletOptions: {
-      path:
-        config.get('paths.tokenWallets') +
-        '/' +
-        this.generateTokenWalletFilename(
-          config.get('api.host'),
-          config.get('api.port'),
-          config.get('auth.clientId')
-        )
+      path: `${config.get('paths.tokenWallets')}/token.${config.get(
+        'api.host'
+      )}${config.get('api.port')}.${config.get('auth.clientId')}.json`
     }
   })
 }

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -114,15 +114,13 @@ module.exports.validateRequestCredentials = function (req, res) {
     res.statusCode = 401
     res.end()
     return false
-  }
-
-  if (clientId !== authConfig.clientId || secret !== authConfig.secret) {
+  } else if (clientId !== authConfig.clientId || secret !== authConfig.secret) {
     res.statusCode = 401
     res.end()
     return false
+  } else {
+    return true
   }
-
-  return true
 }
 
 /**

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -17,8 +17,6 @@ const config = require(path.join(__dirname, '/../../config.js'))
 const Passport = require('@dadi/passport')
 const errorView = require(path.join(__dirname, '/view/errors'))
 
-var self = this
-
 module.exports.getVersion = function () {
   if (config.get('debug')) return version
 }
@@ -246,27 +244,13 @@ module.exports.clearCache = function (req, Cache, callback) {
 }
 
 /**
- * Creates a URL/filename friendly version (slug) of any object that implements `toString()`
- * @param {Object} input - object to be slugified
- */
-module.exports.slugify = function (input) {
-  return require('underscore.string').slugify(input.toString())
-}
-
-/**
  * Generates a filename for a token wallet file
  * @param {String} host - Issuer host
  * @param {Number} port - Issuer port
  * @param {String} clientId - Client ID
  */
 module.exports.generateTokenWalletFilename = function (host, port, clientId) {
-  return (
-    'token.' +
-    self.slugify(host + port) +
-    '.' +
-    self.slugify(clientId) +
-    '.json'
-  )
+  return `token.${host}${port}.${clientId}.json`
 }
 
 module.exports.getToken = function () {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -407,8 +407,6 @@ Server.prototype.loadApi = function (options, reload, callback) {
             message: 'Cache cleared successfully'
           })
         })
-      } else {
-        next()
       }
     })
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "snyk": "^1.47.0",
     "through": "~2.3.8",
     "toobusy-js": "~0.5.1",
-    "underscore.string": "~3.3.0",
     "wildcard": "~1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Looking at this function - is it needed? I think we're covered because the `host` has to be either an IP address (valid as a filename), OR a hostname, which are also valid directly as filenames?

Maybe [this](https://github.com/parshap/node-sanitize-filename) might be more robust to account for random chars in `clientId`? 