### PR TITLE
Rename markdown provider

### DIFF
--- a/dadi/lib/providers/text.js
+++ b/dadi/lib/providers/text.js
@@ -4,14 +4,13 @@ const async = require('async')
 const formatError = require('@dadi/format-error')
 const fs = require('fs')
 const path = require('path')
-const marked = require('marked')
 const meta = require('@dadi/metadata')
 const recursive = require('recursive-readdir')
 const yaml = require('js-yaml')
 
 const help = require(path.join(__dirname, '../help'))
 
-const MarkdownProvider = function () {}
+const TextProvider = function () {}
 
 /**
  * initialise - initialises the datasource provider
@@ -20,7 +19,7 @@ const MarkdownProvider = function () {}
  * @param  {obj} schema - the schema that this provider works with
  * @return {void}
  */
-MarkdownProvider.prototype.initialise = function (datasource, schema) {
+TextProvider.prototype.initialise = function (datasource, schema) {
   this.datasource = datasource
   this.schema = schema
   this.extension = schema.datasource.source.extension
@@ -34,7 +33,7 @@ MarkdownProvider.prototype.initialise = function (datasource, schema) {
  * @param  {?} obj - sort parameter
  * @return {?}
  */
-MarkdownProvider.prototype.processSortParameter = function (obj) {
+TextProvider.prototype.processSortParameter = function (obj) {
   let sort = {}
 
   if (
@@ -61,7 +60,7 @@ MarkdownProvider.prototype.processSortParameter = function (obj) {
  * @param  {fn} done - callback on error or completion
  * @return {void}
  */
-MarkdownProvider.prototype.load = function (requestUrl, done) {
+TextProvider.prototype.load = function (requestUrl, done) {
   try {
     const sourcePath = path.normalize(this.schema.datasource.source.path)
 
@@ -173,17 +172,17 @@ MarkdownProvider.prototype.load = function (requestUrl, done) {
  * @param  {obj} req - web request object
  * @return {void}
  */
-MarkdownProvider.prototype.processRequest = function (datasourceParams) {
+TextProvider.prototype.processRequest = function (datasourceParams) {
   this.datasourceParams = datasourceParams
 }
 
-MarkdownProvider.prototype.readFileAsync = function (filename, callback) {
+TextProvider.prototype.readFileAsync = function (filename, callback) {
   fs.readFile(filename, 'utf8', function (err, data) {
     return callback(err, { _name: filename, _contents: data })
   })
 }
 
-MarkdownProvider.prototype.parseRawDataAsync = function (data, callback) {
+TextProvider.prototype.parseRawDataAsync = function (data, callback) {
   const yamlRegex = /---[\n\r]+([\s\S]*)[\n\r]+---[\n\r]+([\s\S]*)/
   const posts = []
 
@@ -200,7 +199,6 @@ MarkdownProvider.prototype.parseRawDataAsync = function (data, callback) {
 
     if (attributes) {
       const contentText = bits[2] || ''
-      const contentHtml = marked(contentText)
       const parsedPath = path.parse(data[i]._name)
 
       // Some info about the file
@@ -218,8 +216,7 @@ MarkdownProvider.prototype.parseRawDataAsync = function (data, callback) {
       posts.push({
         attributes,
         original: data[i]._contents,
-        contentText,
-        contentHtml
+        contentText
       })
     }
   }
@@ -227,4 +224,4 @@ MarkdownProvider.prototype.parseRawDataAsync = function (data, callback) {
   callback(null, posts)
 }
 
-module.exports = MarkdownProvider
+module.exports = TextProvider

--- a/dadi/lib/providers/text.js
+++ b/dadi/lib/providers/text.js
@@ -24,7 +24,7 @@ TextProvider.prototype.initialise = function (datasource, schema) {
   this.schema = schema
   this.extension = schema.datasource.source.extension
     ? schema.datasource.source.extension
-    : 'md'
+    : 'txt'
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/web",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6234,11 +6234,6 @@
       "requires": {
         "object-visit": "1.0.1"
       }
-    },
-    "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "iltorb": "~2.1.0",
     "js-yaml": "~3.10.0",
     "kinesis": "~1.2.2",
-    "marked": "~0.3.9",
     "mime-types": "~2.1.17",
     "mongodb": "~2.2.0",
     "multer": "^1.3.0",

--- a/test/app/datasources/text.json
+++ b/test/app/datasources/text.json
@@ -3,8 +3,9 @@
     "key": "markdown",
     "name": "Markdown DS",
     "source": {
-      "type": "markdown",
-      "path": "./test/app/public"
+      "type": "text",
+      "path": "./test/app/public",
+      "extension": "md"
     },
     "paginate": true,
     "count": 1,

--- a/test/unit/data-providers.js
+++ b/test/unit/data-providers.js
@@ -18,7 +18,6 @@ var Page = require(__dirname + "/../../dadi/lib/page")
 var apiProvider = require(__dirname + "/../../dadi/lib/providers/dadiapi")
 var remoteProvider = require(__dirname + "/../../dadi/lib/providers/remote")
 var restProvider = require(__dirname + "/../../dadi/lib/providers/restapi")
-var markdownProvider = require(__dirname + "/../../dadi/lib/providers/markdown")
 
 var config = require(path.resolve(path.join(__dirname, "/../../config")))
 var controller
@@ -817,11 +816,11 @@ describe("Data Providers", function(done) {
     })
   })
 
-  describe("Markdown", function(done) {
+  describe("Text", function(done) {
     it("should process frontmatter from the files in the datasource path", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
 
       sinon
@@ -831,7 +830,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =
@@ -871,7 +870,7 @@ describe("Data Providers", function(done) {
     it("should return correct pagination metadata", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
 
       sinon
@@ -881,7 +880,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =
@@ -911,7 +910,7 @@ describe("Data Providers", function(done) {
     it("should use the datasource requestParams to filter the results", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
 
       sinon
@@ -921,7 +920,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
           pages[0].routes[0].path = "/test/:category?"
 
           TestHelper.startServer(pages).then(() => {
@@ -953,7 +952,7 @@ describe("Data Providers", function(done) {
     it("should return the number of records specified by the count property", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
 
       sinon
@@ -963,7 +962,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =
@@ -989,7 +988,7 @@ describe("Data Providers", function(done) {
     it("should process files of a specified extension", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
       dsSchema.datasource.source.extension = "txt"
 
@@ -1000,7 +999,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =
@@ -1029,7 +1028,7 @@ describe("Data Providers", function(done) {
     it("should return an error if the source folder does not exist", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
       dsSchema.datasource.source.path = "./foobar"
 
@@ -1040,7 +1039,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =
@@ -1068,7 +1067,7 @@ describe("Data Providers", function(done) {
     it("should ignore malformed dates in a source file", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
       dsSchema.datasource.source.extension = "txt"
 
@@ -1079,7 +1078,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =
@@ -1107,7 +1106,7 @@ describe("Data Providers", function(done) {
     it("should sort by the specified field in reverse order if set to -1", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
 
       delete dsSchema.datasource.sort.date
@@ -1121,7 +1120,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =
@@ -1152,7 +1151,7 @@ describe("Data Providers", function(done) {
     it("should only return the selected fields as specified by the datasource", function(done) {
       var dsSchema = TestHelper.getSchemaFromFile(
         TestHelper.getPathOptions().datasourcePath,
-        "markdown"
+        "text"
       )
       dsSchema.datasource.fields = ["attributes.title", "attributes._id"]
       dsSchema.datasource.count = 2
@@ -1164,7 +1163,7 @@ describe("Data Providers", function(done) {
       TestHelper.disableApiConfig().then(() => {
         TestHelper.updateConfig({ allowDebugView: true }).then(() => {
           var pages = TestHelper.setUpPages()
-          pages[0].datasources = ["markdown"]
+          pages[0].datasources = ["text"]
 
           TestHelper.startServer(pages).then(() => {
             var connectionString =


### PR DESCRIPTION
See ticket #379 

* Removes the `marked` package 
* Provider rename: `"type": "markdown"` becomes `"type": "text"`
* Default extension to `txt`

**This is a breaking change for anyone that uses a datasource `markdown`** , the object `contentHtml` has been removed, but `contentText` remains untouched so you are free to do your own parsing without needless overhead.

Migration example:

## Before
```json
{
  "datasource": {
    "key": "news",
    "source": {
      "type": "markdown",
      "path": "./content/news"
    },
    "paginate": true,
    "count": 12,
    "sort": {
      "attributes.date": 0
    }
  }
}
```

```es6
${text.results.map(i => `
  <h2>${i.attributes.title}</h2>
  ${i.attributes.contentHtml}
`).join('')}
```

## After

```json
{
  "datasource": {
    "key": "news",
    "source": {
      "type": "text",
      "path": "./content/news",
      "extension": "md"
    },
    "paginate": true,
    "count": 12,
    "sort": {
      "attributes.date": 0
    }
  }
}
```

```es6
${text.results.map(i => `
  <h2>${i.attributes.title}</h2>
  ${markdown(i.attributes.contentText)}
`).join('')}
```

```javascript
const marked = require('marked')

module.exports.markdown = chunk => {
  if (!chunk) return
  return marked(chunk)
}
```
N.B. `npm i marked`