### PR TITLE
Add branch name check to precommit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "posttest": "node ./scripts/coverage.js",
     "snyk-protect": "snyk protect",
     "prepublishOnly": "npm run snyk-protect",
-    "precommit": "lint-staged",
+    "precommit": "node scripts/precommit.js && lint-staged",
     "commitmsg": "commitlint -e",
     "format": "prettier-standard '{dadi,scripts,test}/{!(app),*}/*.js'",
     "prepare": "npm run snyk-protect"

--- a/scripts/precommit.js
+++ b/scripts/precommit.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const exec = require('child_process').exec
+
+function currentBranch () {
+  return new Promise((resolve, reject) => {
+    exec('git branch --no-color', (err, out) => {
+      if (err) return reject(err)
+
+      let branches = out.split('\n')
+      let branch = branches.find(branch => {
+        return /^\*/.test(branch)
+      })
+
+      branch = branch.replace('*', '')
+      branch = branch.trim()
+
+      return resolve(branch)
+    })
+  })
+}
+
+currentBranch().then(branch => {
+  console.log('Checking valid branch name...')
+
+  if (branch !== 'master' &&
+    branch !== 'develop' &&
+    !/^feature\//.test(branch) &&
+    !/^patch\//.test(branch) &&
+    !/^release-/.test(branch)
+  ) {
+    console.log()
+    console.log('Branch name invalid.')
+    console.log('Please use topic branches named "feature/...", or "patch/..."')
+    console.log()
+
+    process.exit(1)
+  } else {
+    console.log('Branch name OK.')
+    process.exit(0)
+  }
+})


### PR DESCRIPTION
This PR introduces a script to be run as a precommit hook to ensure the current branch name matches one of the allowed feature/patch/release/develop/master