### PR TITLE
Several modifications

### DIFF
--- a/dadi/lib/datasource/index.js
+++ b/dadi/lib/datasource/index.js
@@ -169,8 +169,18 @@ Datasource.prototype.loadDatasource = function (done) {
 
   try {
     const body = fs.readFileSync(filepath, { encoding: 'utf-8' })
-
     schema = JSON.parse(body)
+
+    // If the schema has been provided as a flat structure,
+    // without the "datasource" property, wrap the provided data
+    // in a new "datasource" property
+    if (!schema.datasource) {
+      schema = {
+        datasource: {
+          ...schema
+        }
+      }
+    }
     done(null, schema)
   } catch (err) {
     log.error(

--- a/dadi/lib/page/index.js
+++ b/dadi/lib/page/index.js
@@ -11,7 +11,7 @@ const Page = function (name, schema, hostKey, templateCandidate) {
   schema.settings = schema.settings || {}
 
   this.name = name
-  this.key = schema.page.key || name
+  this.key = schema.page && schema.page.key ? schema.page.key : name
   this.hostKey = hostKey || ''
   this.template = schema.template || templateCandidate
   this.contentType = schema.contentType || 'text/html'

--- a/dadi/lib/providers/dadiapi.js
+++ b/dadi/lib/providers/dadiapi.js
@@ -369,6 +369,11 @@ DadiApiProvider.prototype.processDatasourceParameters = function (
     params.push({ cache: datasourceParams.cache })
   }
 
+  // pass compose parameter to API endpoint
+  if (datasourceParams.hasOwnProperty('compose')) {
+    params.push({ compose: datasourceParams.compose })
+  }
+
   // pass language to api endpoint
   if (datasourceParams.lang) {
     params.push({ lang: datasourceParams.lang })

--- a/test/unit/datasource.js
+++ b/test/unit/datasource.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const path = require('path')
 const should = require('should')
 const sinon = require('sinon')
@@ -52,14 +53,45 @@ describe('Datasource', done => {
     const p = page(name, schema)
     const dsName = 'car_makes'
     const options = TestHelper.getPathOptions()
+
+    let flattenedSchema = {
+      key: 'car_makes',
+      name: 'Makes datasource',
+      source: {
+        type: 'static',
+        endpoint: '1.0/cars/makes'
+      },
+      caching: {
+        ttl: 300,
+        directory: {
+          enabled: true,
+          path: './cache/web/',
+          extension: 'json'
+        },
+        redis: {
+          enabled: false
+        }
+      },
+      paginate: true,
+      count: 20,
+      sort: { name: 1 },
+      fields: { name: 1, _id: 0 },
+      requestParams: [{ param: 'make', field: 'name' }]
+    }
+
+    let filePath = options.datasourcePath + '/' + dsName + '.json'
+    let stub = sinon
+      .stub(fs, 'readFileSync')
+      .withArgs(filePath, { encoding: 'utf-8' })
+      .callsFake(() => {
+        return JSON.stringify(flattenedSchema)
+      })
+
     new Datasource(p, dsName, options).init((err, ds) => {
       if (err) done(err)
-      const fsSchema = TestHelper.getSchemaFromFile(
-        options.datasourcePath,
-        dsName,
-        null
-      )
-      ds.schema.datasource.key.should.eql(fsSchema.datasource.key)
+
+      fs.readFileSync.restore()
+      ds.schema.datasource.key.should.eql('car_makes')
       done()
     })
   })
@@ -266,6 +298,7 @@ describe('Datasource', done => {
     const schema = TestHelper.getPageSchema()
     const dsName = 'car_makes_nosource'
 
+    config.set('api.host', '127.0.0.1')
     config.set('api.port', 80)
 
     new Datasource(null, dsName, TestHelper.getPathOptions()).init(

--- a/test/unit/datasource.js
+++ b/test/unit/datasource.js
@@ -858,6 +858,36 @@ describe('Datasource', done => {
       })
     })
 
+    it('should pass compose param to the endpoint', done => {
+      const name = 'test'
+      const schema = TestHelper.getPageSchema()
+      const p = page(name, schema)
+      const dsName = 'car_makes'
+      const options = TestHelper.getPathOptions()
+      const dsSchema = TestHelper.getSchemaFromFile(
+        options.datasourcePath,
+        dsName
+      )
+
+      // modify the endpoint to give it a compose setting
+      dsSchema.datasource.compose = 'all'
+
+      sinon
+        .stub(Datasource.Datasource.prototype, 'loadDatasource')
+        .yields(null, dsSchema)
+
+      const req = { params: {}, url: '/1.0/makes/ford/2' }
+
+      new Datasource(p, dsName, options).init((err, ds) => {
+        Datasource.Datasource.prototype.loadDatasource.restore()
+        ds.processRequest(dsName, req)
+        ds.provider.endpoint.should.eql(
+          'http://127.0.0.1:3000/1.0/cars/makes?count=20&page=1&filter={}&fields={"name":1,"_id":0}&sort={"name":1}&compose=all'
+        )
+        done()
+      })
+    })
+
     it('should pass page param to the endpoint when page.passFilters is true', done => {
       const name = 'test'
       const schema = TestHelper.getPageSchema()

--- a/test/unit/page.js
+++ b/test/unit/page.js
@@ -35,6 +35,14 @@ describe('Page', done => {
     done()
   })
 
+  it('should use filename if no name supplied', done => {
+    const name = 'test-no-name-given'
+    const schema = TestHelper.getPageSchema()
+    delete schema.page
+    page(name, schema).key.should.eql('test-no-name-given')
+    done()
+  })
+
   it('should attach key using name if not supplied', done => {
     const name = 'test'
     const schema = TestHelper.getPageSchema()


### PR DESCRIPTION
### Allow flattened datasource specification files, to match the page specification files. This is backwards compatible, the datasource property is added internally.

```
{
    key: 'car_makes',
    name: 'Makes datasource',
    source: [Object],
    paginate: true,
    compose: "all",
    count: 20,
    search: {},
    filter: {}
}
```

### Allow page specification files without the "page" block, using the filename as the page name internally.

Both the following examples will work:
```
{
  "page": {
    "name": "index"
  },
  "routes": [
    {
      "path": "/"
    }
  ]
}
```

```
{
  "routes": [
    {
      "path": "/"
    }
  ]
}
```

### Allow "composed" option in datasources. The value will be added to the API endpoint.

```
{
  datasource: {
    key: 'car_makes',
    name: 'Makes datasource',
    source: [Object],
    paginate: true,
    compose: "all",
    count: 20,
    search: {},
    filter: {}
  }
}
```

Close #263
Close #438
Close #479
