### PR TITLE
Fix template loading process

### DIFF
--- a/dadi/lib/monitor/index.js
+++ b/dadi/lib/monitor/index.js
@@ -1,0 +1,40 @@
+/**
+ * @module Monitor
+ */
+const util = require('util')
+const EventEmitter = require('events').EventEmitter
+const fs = require('fs')
+
+const Monitor = function (path) {
+  if (!path) throw new Error('Must provide path to instantiate Monitor')
+
+  this.path = path
+
+  const self = this
+
+  try {
+    this.watcher = fs.watch(
+      this.path,
+      { recursive: true },
+      (eventName, filename) => {
+        self.emit('change', filename)
+      }
+    )
+  } catch (err) {
+    // Do nothing if folder doesn't exist
+  }
+}
+
+// inherits from EventEmitter
+util.inherits(Monitor, EventEmitter)
+
+Monitor.prototype.close = function () {
+  if (this.watcher) this.watcher.close.apply(this.watcher, arguments)
+}
+
+// exports
+module.exports = function (path) {
+  return new Monitor(path)
+}
+
+module.exports.Monitor = Monitor

--- a/test/unit/monitor.js
+++ b/test/unit/monitor.js
@@ -1,7 +1,10 @@
 const fs = require('fs')
 const path = require('path')
 const should = require('should')
+const sinon = require('sinon')
 
+const api = require(`${__dirname}/../../dadi/lib/api`)
+const monitor = require(`${__dirname}/../../dadi/lib/monitor`)
 const Server = require(`${__dirname}/../../dadi/lib`)
 const TestHelper = require(`${__dirname}/../help`)()
 
@@ -19,24 +22,30 @@ describe('Monitor', done => {
     done()
   })
 
+  it('should export constructor', done => {
+    monitor.Monitor.should.be.a.Function
+    done()
+  })
+
+  it('should export function that returns an instance', done => {
+    monitor.should.be.a.Function
+    const p = __dirname
+    monitor(p).should.be.an.instanceOf(monitor.Monitor)
+    done()
+  })
+
   it('should fire `change` event when watched path changes', done => {
     const p = path.join(__dirname, 'test.txt')
 
-    let server = Server({})
+    fs.writeFile(p, 'Hello World', err => {
+      const m = monitor(p)
+      m.on('change', fileName => {
+        fileName.should.eql('test.txt')
+      })
 
-    let called = false
+      m.close()
 
-    server.addMonitor(p, () => {
-      if (!called) {
-        called = true
-        setTimeout(() => {
-          done()
-        }, 1000)
-      }
+      done()
     })
-
-    setTimeout(() => {
-      fs.writeFile(p, 'Hello World', err => {})
-    }, 1000)
   })
 })


### PR DESCRIPTION
This PR reverts the change from 7.0.0 that introduced a new file watch process to allow hot reload of pages.

In addition, a change was introduced in 7.0.0 that loads page files by reading them, rather than using `require`, which meant picking up any changes requires deleting the key from the require.cache ... etc. This PR modifies that change to make it a sync read file. 